### PR TITLE
SourceType Kustomize Directory

### DIFF
--- a/reporthandling/datastructuresv1.go
+++ b/reporthandling/datastructuresv1.go
@@ -94,18 +94,20 @@ type PostureReport struct {
 }
 
 const (
-	SourceTypeJson      string = "JSON"
-	SourceTypeYaml      string = "YAML"
-	SourceTypeHelmChart string = "Helm Chart"
+	SourceTypeJson               string = "JSON"
+	SourceTypeYaml               string = "YAML"
+	SourceTypeHelmChart          string = "Helm Chart"
+	SourceTypeKustomizeDirectory string = "Kustomize Directory"
 )
 
 // Source - File source metadata
 type Source struct {
-	Path          string     `json:"path,omitempty"`          // deprecated
-	RelativePath  string     `json:"relativePath,omitempty"`  // relative path from the repo base
-	FileType      string     `json:"fileType,omitempty"`      // file type
-	HelmChartName string     `json:"helmChartName,omitempty"` // helm chart name (if FileType is "Helm Chart")
-	LastCommit    LastCommit `json:"lastCommit,omitempty"`
+	Path                   string     `json:"path,omitempty"`                   // deprecated
+	RelativePath           string     `json:"relativePath,omitempty"`           // relative path from the repo base
+	FileType               string     `json:"fileType,omitempty"`               // file type
+	HelmChartName          string     `json:"helmChartName,omitempty"`          // helm chart name (if FileType is "Helm Chart")
+	KustomizeDirectoryName string     `json:"kustomizeDirectoryName,omitempty"` //Kustomize Directory name if File is from Kustomize Directory
+	LastCommit             LastCommit `json:"lastCommit,omitempty"`
 }
 
 // LastCommit - file in git repo last commit metadata


### PR DESCRIPTION
* Added `SorceTypeKustomizeDirectory` to identify the K8s Workloads from Kustomize Directory.
* Added the `KustomizeDirectoryName` field to the `Source` struct to store the name of the Kustomize Directory.


* This is associated with kubescape/kubescape#795

