### PR TITLE
fix: check uniqueness enforcement after checking list union

### DIFF
--- a/reporthandling/helpers/v1/listing_test.go
+++ b/reporthandling/helpers/v1/listing_test.go
@@ -42,10 +42,12 @@ func TestAllLists(t *testing.T) {
 func TestAllListsUpdate(t *testing.T) {
 	listA := mockAllListsA()
 	listB := mockAllListsB()
-	listB.Update(listA)
-	listB.ToUnique()
 
+	// Updating list A to contain list B should contain all resources, even duplicates
+	listB.Update(listA)
 	assert.Equal(t, 24, listB.All().Len())
+
+	// Enforcing unique resources should prune duplicate resources
 	listB.ToUniqueResources()
 	assert.Equal(t, 11, listB.All().Len())
 


### PR DESCRIPTION
# What this PR changes?

Conflicts between b530545 (PR #26) and 438030d (PR #30) broke tests. This PR fixes them.