### PR TITLE
feat: support severity counters in report summary

### DIFF
--- a/reporthandling/apis/severity.go
+++ b/reporthandling/apis/severity.go
@@ -1,6 +1,14 @@
 package apis
 
 const (
+	SeverityCriticalString = "Critical"
+	SeverityHighString     = "High"
+	SeverityMediumString   = "Medium"
+	SeverityLowString      = "Low"
+	SeverityUnknownString  = "Unknown"
+)
+
+const (
 	SeverityUnknown  = iota
 	SeverityLow      = iota
 	SeverityMedium   = iota
@@ -30,15 +38,15 @@ func SeverityNumberToString(severityNumber int) string {
 	*/
 	switch severityNumber {
 	case SeverityCritical:
-		return "Critical"
+		return SeverityCriticalString
 	case SeverityHigh:
-		return "High"
+		return SeverityHighString
 	case SeverityMedium:
-		return "Medium"
+		return SeverityMediumString
 	case SeverityLow:
-		return "Low"
+		return SeverityLowString
 	default:
-		return "Unknown"
+		return SeverityUnknownString
 	}
 
 }

--- a/reporthandling/results/v1/reportsummary/datastructures.go
+++ b/reporthandling/results/v1/reportsummary/datastructures.go
@@ -14,7 +14,7 @@ type ControlSummaries map[string]ControlSummary
 
 // SummaryDetails detailed summary of the scanning. will contain versions, counters, etc.
 type SummaryDetails struct {
-	SeverityCounters ISeverityCounters   `json:"severityCounters,omitempty"`
+	SeverityCounters SeverityCounters   `json:"severityCounters,omitempty"`
 	Controls         ControlSummaries    `json:"controls,omitempty"` // mapping of control - map[<control ID>]<control summary>
 	Status           apis.ScanningStatus `json:"status"`             // overall status
 	Frameworks       []FrameworkSummary  `json:"frameworks"`         // list of framework summary

--- a/reporthandling/results/v1/reportsummary/severitycounters.go
+++ b/reporthandling/results/v1/reportsummary/severitycounters.go
@@ -1,10 +1,13 @@
 package reportsummary
 
+import "github.com/kubescape/opa-utils/reporthandling/apis"
+
 type ISeverityCounters interface {
 	NumberOfResourcesWithCriticalSeverity() int
 	NumberOfResourcesWithHighSeverity() int
 	NumberOfResourcesWithMediumSeverity() int
 	NumberOfResourcesWithLowSeverity() int
+	Increase(severity string, amount int)
 }
 
 func (sc *SeverityCounters) NumberOfResourcesWithCriticalSeverity() int {
@@ -21,4 +24,25 @@ func (sc *SeverityCounters) NumberOfResourcesWithMediumSeverity() int {
 
 func (sc *SeverityCounters) NumberOfResourcesWithLowSeverity() int {
 	return sc.ResourcesWithLowSeverityCounter
+}
+
+// Increase increments the counter of a given severity by a given amount
+func (sc *SeverityCounters) Increase(severity string, amount int) {
+	var counterToIncrement *int
+
+	switch severity {
+	case apis.SeverityCriticalString:
+		counterToIncrement = &sc.ResourcesWithCriticalSeverityCounter
+	case apis.SeverityHighString:
+		counterToIncrement = &sc.ResourcesWithHighSeverityCounter
+	case apis.SeverityMediumString:
+		counterToIncrement = &sc.ResourcesWithMediumSeverityCounter
+	case apis.SeverityLowString:
+		counterToIncrement = &sc.ResourcesWithLowSeverityCounter
+	// Return without incrementing on unrecognized severities
+	default:
+		return
+	}
+
+	*counterToIncrement++
 }

--- a/reporthandling/results/v1/reportsummary/summarydetails_test.go
+++ b/reporthandling/results/v1/reportsummary/summarydetails_test.go
@@ -149,7 +149,7 @@ func TestSummaryDetails_GetResourcesSeverityCounters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sc := &SummaryDetails{
-				SeverityCounters: &tt.fields.SeverityCounters,
+				SeverityCounters: tt.fields.SeverityCounters,
 			}
 
 			if got := sc.SeverityCounters.NumberOfResourcesWithCriticalSeverity(); got != tt.want.SeverityCounters.ResourcesWithCriticalSeverityCounter {


### PR DESCRIPTION
# What this PR changes?

Previously, we have added severity counters.
This commit adds support for the severity counters to the report summary, namely:
- Updating the counters whenever a new resources is added to the report.