### PR TITLE
feat: export a list supported severities

### DIFF
--- a/reporthandling/apis/severity.go
+++ b/reporthandling/apis/severity.go
@@ -17,6 +17,11 @@ const (
 )
 const NumberOfSeverities = 5
 
+// GetSupportedSeverities returns a slice of supported severities
+func GetSupportedSeverities() []string {
+	return []string{SeverityLowString, SeverityMediumString, SeverityHighString, SeverityCriticalString}
+}
+
 func ControlSeverityToString(baseScore float32) string {
 	/*
 		9+	Critical

--- a/reporthandling/apis/severity_test.go
+++ b/reporthandling/apis/severity_test.go
@@ -1,0 +1,16 @@
+package apis
+
+import (
+	"reflect"
+	"testing"
+)
+
+// GetSupportedSeverities should return a list of supported severities
+func TestGetSupportedSeverities(t *testing.T) {
+	want := []string{"Low", "Medium", "High", "Critical"}
+	got := GetSupportedSeverities()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
# What this PR changes?

This commit adds a function that returns a list of supported severities. Required to unify severity thresholds into one command-line flag.