### PR TITLE
Support in getting releases from rego dev releasesDev

### DIFF
--- a/gitregostore/datastructures.go
+++ b/gitregostore/datastructures.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"sync"
 
 	// "github.com/armosec/capacketsgo/opapolicy"
@@ -64,7 +65,12 @@ func newGitRegoStore(baseUrl string, owner string, repository string, path strin
 func NewGitRegoStore(baseUrl string, owner string, repository string, path string, tag string, branch string, frequency int) *GitRegoStore {
 	gs := newGitRegoStore(baseUrl, owner, repository, path, tag, branch, frequency)
 	gs.setURL()
-	gs.StripFilesExtention = false
+	if strings.Contains(tag, "latest") {
+		gs.StripFilesExtention = true
+	} else {
+		gs.StripFilesExtention = false
+	}
+
 	return gs
 }
 
@@ -78,7 +84,6 @@ func (gs *GitRegoStore) SetRegoObjects() error {
 // Release files source: "https://github.com/kubescape/regolibrary/releases/latest/download"
 func NewDefaultGitRegoStore(frequency int) *GitRegoStore {
 	gs := NewGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "latest/download", "", frequency)
-	gs.StripFilesExtention = true
 	return gs
 }
 

--- a/gitregostore/datastructures.go
+++ b/gitregostore/datastructures.go
@@ -40,6 +40,7 @@ type GitRegoStore struct {
 	SystemPostureExceptionPolicies     []armotypes.PostureExceptionPolicy
 	FrequencyPullFromGitMinutes        int
 	Watch                              bool
+	StripFilesExtention                bool
 }
 
 func newGitRegoStore(baseUrl string, owner string, repository string, path string, tag string, branch string, frequency int) *GitRegoStore {
@@ -63,6 +64,7 @@ func newGitRegoStore(baseUrl string, owner string, repository string, path strin
 func NewGitRegoStore(baseUrl string, owner string, repository string, path string, tag string, branch string, frequency int) *GitRegoStore {
 	gs := newGitRegoStore(baseUrl, owner, repository, path, tag, branch, frequency)
 	gs.setURL()
+	gs.StripFilesExtention = false
 	return gs
 }
 
@@ -72,8 +74,19 @@ func (gs *GitRegoStore) SetRegoObjects() error {
 	return err
 }
 
+// NewDefaultGitRegoStore - generates git store object for production regolibrary release files.
+// Release files source: "https://github.com/kubescape/regolibrary/releases/latest/download"
 func NewDefaultGitRegoStore(frequency int) *GitRegoStore {
-	return NewGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "latest/download", "", frequency)
+	gs := NewGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "latest/download", "", frequency)
+	gs.StripFilesExtention = true
+	return gs
+}
+
+// NewDevGitRegoStore - generates git store object for dev regolibrary release files
+// Release files source: "https://raw.githubusercontent.com/kubescape/regolibrary/dev/releasesDev"
+func NewDevGitRegoStore(frequency int) *GitRegoStore {
+	gs := NewGitRegoStore("https://raw.githubusercontent.com", "kubescape", "regolibrary", "releasesDev", "", "dev", frequency)
+	return gs
 }
 
 // Deprecated

--- a/gitregostore/datastructures.go
+++ b/gitregostore/datastructures.go
@@ -83,9 +83,9 @@ func NewDefaultGitRegoStore(frequency int) *GitRegoStore {
 }
 
 // NewDevGitRegoStore - generates git store object for dev regolibrary release files
-// Release files source: "https://raw.githubusercontent.com/kubescape/regolibrary/dev/releasesDev"
+// Release files source: "https://raw.githubusercontent.com/kubescape/regolibrary/dev/releaseDev"
 func NewDevGitRegoStore(frequency int) *GitRegoStore {
-	gs := NewGitRegoStore("https://raw.githubusercontent.com", "kubescape", "regolibrary", "releasesDev", "", "dev", frequency)
+	gs := NewGitRegoStore("https://raw.githubusercontent.com", "kubescape", "regolibrary", "releaseDev", "", "dev", frequency)
 	return gs
 }
 

--- a/gitregostore/gitstoremethods_test.go
+++ b/gitregostore/gitstoremethods_test.go
@@ -218,3 +218,66 @@ func TestGetPoliciesMethodsNew(t *testing.T) {
 		t.Errorf("failed to get framework by name: '%s', %v", frameworksNames[0], err)
 	}
 }
+
+// func TestGetPoliciesMethodsDev(t *testing.T) {
+// 	gs := NewDevGitRegoStore(-1)
+// 	err := gs.SetRegoObjects()
+// 	if err != nil {
+// 		t.Errorf("error in SetRegoObjects: %v", err)
+// 	}
+// 	index := 0
+
+// 	// Rules
+// 	policies, err := gs.GetOPAPolicies()
+// 	if err != nil || policies == nil {
+// 		t.Errorf("failed to get all policies %v", err)
+// 	}
+// 	policiesNames, err := gs.GetOPAPoliciesNamesList()
+// 	if err != nil || len(policiesNames) == 0 {
+// 		t.Errorf("failed to get policies names list %v", err)
+// 		return
+// 	}
+// 	policy, err := gs.GetOPAPolicyByName(policiesNames[index])
+// 	if err != nil || policy == nil {
+// 		t.Errorf("failed to get policy by name: '%s', %v", policiesNames[index], err)
+// 	}
+// 	// Controls
+// 	controls, err := gs.GetOPAControls()
+// 	if err != nil || controls == nil {
+// 		t.Errorf("failed to get all controls %v", err)
+// 	}
+// 	controlsNames, err := gs.GetOPAControlsNamesList()
+// 	if err != nil || len(controlsNames) == 0 {
+// 		t.Errorf("failed to get controls names list %v", err)
+// 		return
+// 	}
+
+// 	control, err := gs.GetOPAControlByName(controlsNames[index])
+// 	if err != nil || control == nil {
+// 		t.Errorf("failed to get control by name: '%s', %v", controlsNames[index], err)
+// 	}
+// 	controlsIDs, err := gs.GetOPAControlsIDsList()
+// 	if err != nil || len(controlsIDs) == 0 {
+// 		t.Errorf("failed to get controls ids list %v", err)
+// 		return
+// 	}
+
+// 	control, err = gs.GetOPAControlByID(controlsIDs[index])
+// 	if err != nil || control == nil {
+// 		t.Errorf("failed to get control by ID: '%s', %v", controlsNames[index], err)
+// 	}
+// 	// Frameworks
+// 	frameworks, err := gs.GetOPAFrameworks()
+// 	if err != nil || frameworks == nil {
+// 		t.Errorf("failed to get all frameworks %v", err)
+// 	}
+// 	frameworksNames, err := gs.GetOPAFrameworksNamesList()
+// 	if err != nil || len(frameworksNames) == 0 {
+// 		t.Errorf("failed to get frameworks names list %v", err)
+// 		return
+// 	}
+// 	framework, err := gs.GetOPAFrameworkByName(frameworksNames[0])
+// 	if err != nil || framework == nil {
+// 		t.Errorf("failed to get framework by name: '%s', %v", frameworksNames[0], err)
+// 	}
+// }

--- a/gitregostore/gitstoreutils.go
+++ b/gitregostore/gitstoreutils.go
@@ -34,7 +34,7 @@ const (
 	controlIDRegex = `^(?:[a-z]+|[A-Z]+)(?:[\-][v]?(?:[0-9][\.]?)+)(?:[\-]?[0-9][\.]?)+$`
 
 	productionReleaseURL = "https://github.com/kubescape/regolibrary/releases/latest/download"
-	devReleaseURL        = "https://raw.githubusercontent.com/kubescape/regolibrary/dev/releasesDev"
+	devReleaseURL        = "https://raw.githubusercontent.com/kubescape/regolibrary/dev/releaseDev"
 )
 
 var controlIDRegexCompiled *regexp.Regexp = nil

--- a/gitregostore/gitstoreutils.go
+++ b/gitregostore/gitstoreutils.go
@@ -33,8 +33,7 @@ const (
 
 	controlIDRegex = `^(?:[a-z]+|[A-Z]+)(?:[\-][v]?(?:[0-9][\.]?)+)(?:[\-]?[0-9][\.]?)+$`
 
-	productionReleaseURL = "https://github.com/kubescape/regolibrary/releases/latest/download"
-	devReleaseURL        = "https://raw.githubusercontent.com/kubescape/regolibrary/dev/releaseDev"
+
 )
 
 var controlIDRegexCompiled *regexp.Regexp = nil


### PR DESCRIPTION
* Unified production releases and dev releases to use the same methods of data manipulations.
* Added new GitRegoStore constructor NewDevGitRegoStore to get releases from dev branch. The source of dev releases is expected to be at: https://raw.githubusercontent.com/kubescape/regolibrary/dev/releasesDev