### PR TITLE
Change type of ScanMetadata.Format to `slice of strings` from `string`

### DIFF
--- a/httpserver/apis/v1/apis.go
+++ b/httpserver/apis/v1/apis.go
@@ -19,15 +19,15 @@ type ScanResponseType string
 
 const (
 	// Deprecated: will return busy / notBusy instead
-	IDScanResponseType        ScanResponseType = "id"
+	IDScanResponseType ScanResponseType = "id"
 	// ErrorScanResponseType indicates a response that reports an error
-	ErrorScanResponseType     ScanResponseType = "error"
+	ErrorScanResponseType ScanResponseType = "error"
 	// ResultsV1ScanResponseType indicates a response that carries a v1 Results object as payload
 	ResultsV1ScanResponseType ScanResponseType = "v1results"
 	// BusyScanResponseType indicates that a server is busy with a previous request
-	BusyScanResponseType      ScanResponseType = "busy"
+	BusyScanResponseType ScanResponseType = "busy"
 	// NotBusyScanResponseType indicates that a server is not busy with a previous request
-	NotBusyScanResponseType   ScanResponseType = "notBusy"
+	NotBusyScanResponseType ScanResponseType = "notBusy"
 	// ReadyScanResponseType indicates that a server has successfully completed a request
-	ReadyScanResponseType     ScanResponseType = "ready"
+	ReadyScanResponseType ScanResponseType = "ready"
 )

--- a/reporthandling/results/v1/resourcesresults/datastructures_mock.go
+++ b/reporthandling/results/v1/resourcesresults/datastructures_mock.go
@@ -24,12 +24,12 @@ func mockResultPassed() *Result {
 	}
 }
 
-// func mockResultSkipped() *Result {
-// 	return &Result{
-// 		ResourceID:         "resource/passed",
-// 		AssociatedControls: []ResourceAssociatedControl{},
-// 	}
-// }
+//	func mockResultSkipped() *Result {
+//		return &Result{
+//			ResourceID:         "resource/passed",
+//			AssociatedControls: []ResourceAssociatedControl{},
+//		}
+//	}
 func mockResultFailed() *Result {
 	w := workloadinterface.NewWorkloadMock(nil)
 	return &Result{

--- a/reporthandling/v2/datastructures.go
+++ b/reporthandling/v2/datastructures.go
@@ -97,7 +97,7 @@ type ScanMetadata struct {
 	KubescapeVersion   string         `json:"kubescapeVersion,omitempty"`
 	FormatVersion      string         `json:"formatVersion,omitempty"`
 	ControlsInputs     string         `json:"controlsInputs,omitempty"`
-	Format             string         `json:"format,omitempty"`
+	Format             []string       `json:"format,omitempty"`
 	UseExceptions      string         `json:"useExceptions,omitempty"`
 	Logger             string         `json:"logger,omitempty"`
 	ExcludedNamespaces []string       `json:"excludedNamespaces,omitempty"`

--- a/reporthandling/v2/datastructures.go
+++ b/reporthandling/v2/datastructures.go
@@ -93,11 +93,22 @@ const (
 )
 
 type ScanMetadata struct {
-	TargetType         string         `json:"targetType,omitempty"`
-	KubescapeVersion   string         `json:"kubescapeVersion,omitempty"`
-	FormatVersion      string         `json:"formatVersion,omitempty"`
-	ControlsInputs     string         `json:"controlsInputs,omitempty"`
-	Format             []string       `json:"format,omitempty"`
+	TargetType       string `json:"targetType,omitempty"`
+	KubescapeVersion string `json:"kubescapeVersion,omitempty"`
+	FormatVersion    string `json:"formatVersion,omitempty"`
+	ControlsInputs   string `json:"controlsInputs,omitempty"`
+	// Format that has been requested for the output results.
+	//
+	// Since Kubescape added support for multiple outputs, might be not a
+	// single format, but a comma-separated string of the multiple
+	// requested formats.
+	//
+	// Deprecated: Since Kubescape added support for multiple outputs,
+	// `Format` exists only for backward compatibility. Please use the
+	// `Formats` field instead.
+	Format string `json:"format,omitempty"`
+	// Formats that have been requested for the output results.
+	Formats            []string       `json:"formats,omitempty"`
 	UseExceptions      string         `json:"useExceptions,omitempty"`
 	Logger             string         `json:"logger,omitempty"`
 	ExcludedNamespaces []string       `json:"excludedNamespaces,omitempty"`

--- a/reporthandling/v2/datastructures_test.go
+++ b/reporthandling/v2/datastructures_test.go
@@ -94,7 +94,7 @@ func GetPostureReportMock() *PostureReport {
 				ContextName:         "minikube",
 			},
 			ScanMetadata: ScanMetadata{
-				Format:             "json",
+				Format:             []string{"json"},
 				ExcludedNamespaces: []string{"exclude-namespace"},
 				IncludeNamespaces:  []string{"include-namespace"},
 				FailThreshold:      23.54,
@@ -117,7 +117,7 @@ func TestPostureReportMock(t *testing.T) {
 	// t.Error(p.ToString())
 }
 
-//this test validates the unmarshaller that used to validate the posture object in e.r and other places
+// this test validates the unmarshaller that used to validate the posture object in e.r and other places
 func TestPostureReportGojayUnmarshal(t *testing.T) {
 	postureReport := &PostureReport{}
 	original := GetPostureReportMock()

--- a/reporthandling/v2/datastructures_test.go
+++ b/reporthandling/v2/datastructures_test.go
@@ -94,7 +94,8 @@ func GetPostureReportMock() *PostureReport {
 				ContextName:         "minikube",
 			},
 			ScanMetadata: ScanMetadata{
-				Format:             []string{"json"},
+				Format:             "json,pdf,pretty-printer",
+				Formats:            []string{"json", "pdf", "pretty-printer"},
 				ExcludedNamespaces: []string{"exclude-namespace"},
 				IncludeNamespaces:  []string{"include-namespace"},
 				FailThreshold:      23.54,
@@ -117,7 +118,7 @@ func TestPostureReportMock(t *testing.T) {
 	// t.Error(p.ToString())
 }
 
-// this test validates the unmarshaller that used to validate the posture object in e.r and other places
+// TestPostureReportGojayUnmarshal validates the unmarshaller that is used to validate the posture object in e.r and other places
 func TestPostureReportGojayUnmarshal(t *testing.T) {
 	postureReport := &PostureReport{}
 	original := GetPostureReportMock()
@@ -136,6 +137,7 @@ func TestPostureReportGojayUnmarshal(t *testing.T) {
 	assert.Equal(t, original.Metadata.ClusterMetadata.NumberOfWorkerNodes, postureReport.Metadata.ClusterMetadata.NumberOfWorkerNodes)
 	assert.Equal(t, original.Metadata.ClusterMetadata.ContextName, postureReport.Metadata.ClusterMetadata.ContextName)
 	assert.Equal(t, original.Metadata.ScanMetadata.Format, postureReport.Metadata.ScanMetadata.Format)
+	assert.Equal(t, original.Metadata.ScanMetadata.Formats, postureReport.Metadata.ScanMetadata.Formats)
 	assert.Equal(t, original.Metadata.ScanMetadata.ExcludedNamespaces, postureReport.Metadata.ScanMetadata.ExcludedNamespaces)
 	assert.Equal(t, original.Metadata.ScanMetadata.IncludeNamespaces, postureReport.Metadata.ScanMetadata.IncludeNamespaces)
 	assert.Equal(t, original.Metadata.ScanMetadata.FailThreshold, postureReport.Metadata.ScanMetadata.FailThreshold)

--- a/reporthandling/v2/gojayunmarshaller.go
+++ b/reporthandling/v2/gojayunmarshaller.go
@@ -71,7 +71,7 @@ func (m *ScanMetadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err 
 
 	switch key {
 	case "format": // string
-		err = dec.String(&(m.Format))
+		err = dec.SliceString(&(m.Format))
 	case "excludedNamespaces": // []string
 		err = dec.SliceString(&(m.ExcludedNamespaces))
 	case "includeNamespaces": // []string

--- a/reporthandling/v2/gojayunmarshaller.go
+++ b/reporthandling/v2/gojayunmarshaller.go
@@ -48,7 +48,7 @@ func (file *PostureReport) NKeys() int {
 	return 0
 }
 
-// Metadata unmarshaller
+// UnmarshalJSONObject unmarshals incoming JSON data into a Metadata object
 func (m *Metadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err error) {
 
 	switch key {
@@ -66,12 +66,14 @@ func (file *Metadata) NKeys() int {
 	return 0
 }
 
-// ScanMetadata unmarshaler
+// UnmarshalJSONObject unmarshals incoming JSON data into a ScanMetadata object
 func (m *ScanMetadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err error) {
 
 	switch key {
 	case "format": // string
-		err = dec.SliceString(&(m.Format))
+		err = dec.String(&(m.Format))
+	case "formats":
+		err = dec.SliceString(&(m.Formats))
 	case "excludedNamespaces": // []string
 		err = dec.SliceString(&(m.ExcludedNamespaces))
 	case "includeNamespaces": // []string
@@ -103,7 +105,7 @@ func (file *ScanMetadata) NKeys() int {
 	return 0
 }
 
-// ScanMetadata unmarshaller
+// UnmarshalJSONObject unmarshals incoming JSON data into a ClusterMetadata object
 func (m *ClusterMetadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err error) {
 
 	switch key {
@@ -125,5 +127,3 @@ func (m *ClusterMetadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (e
 func (file *ClusterMetadata) NKeys() int {
 	return 0
 }
-
-//------------------------


### PR DESCRIPTION
* This change is required to support getting outputs in multiple formats. 