### PR TITLE
Fix(regostore): fixed data race (lock escalation approach)

### DIFF
--- a/gitregostore/datastructures.go
+++ b/gitregostore/datastructures.go
@@ -22,6 +22,10 @@ type GitRegoStore struct {
 	controlsLock                       sync.RWMutex
 	attackTracksLock                   sync.RWMutex
 	systemPostureExceptionPoliciesLock sync.RWMutex
+	controlRelationsLock               sync.RWMutex
+	frameworkRelationsLock             sync.RWMutex
+	frameworkEscalatedLock             sync.Mutex // escalated X-lock when the object is mutating itself (lazy loaders)
+	controlEscalatedLock               sync.Mutex
 	ControlRuleRelations               dataframe.DataFrame
 	FrameworkControlRelations          dataframe.DataFrame
 	httpClient                         *http.Client

--- a/gitregostore/gitstoremethods_test.go
+++ b/gitregostore/gitstoremethods_test.go
@@ -157,47 +157,58 @@ func gs_tests(t *testing.T, gs *GitRegoStore) {
 }
 
 func TestGetPoliciesMethodsNew(t *testing.T) {
+	t.Parallel()
+
 	gs := NewDefaultGitRegoStore(-1)
-	err := gs.SetRegoObjects()
-	if err != nil {
-		t.Errorf("error in SetRegoObjects: %v", err)
-	}
+	t.Run("shoud set objects in rego store", func(t *testing.T) {
+		require.NoError(t, gs.SetRegoObjects())
+	})
+
 	gs_tests(t, gs)
 
 }
 
 func TestGetOPAFrameworkByName(t *testing.T) {
+	t.Parallel()
+
 	gs := NewDevGitRegoStore(-1)
-	err := gs.SetRegoObjects()
-	if err != nil {
-		t.Errorf("error in SetRegoObjects: %v", err)
-	}
 
-	_, err = gs.GetOPAFrameworkByName("CIS")
+	t.Run("shoud set objects in rego store", func(t *testing.T) {
+		require.NoError(t, gs.SetRegoObjects())
+	})
 
-	if err != nil {
-		t.Errorf("failed to get framework object: %v", err)
-	}
+	t.Run("shoud retrieve CIS framework", func(t *testing.T) {
+		_, err := gs.GetOPAFrameworkByName("CIS")
+		require.NoErrorf(t, err,
+			"failed to get framework object: %v", err,
+		)
+	})
 }
 
 func TestGetPoliciesMethodsOld(t *testing.T) {
+	t.Parallel()
+
 	gs := InitGitRegoStore("https://github.com", "kubescape", "regolibrary", "releases", "latest/download", "", 15)
 
 	gs_tests(t, gs)
 }
 
 func TestGetPoliciesMethodsDevNewParams(t *testing.T) {
+	t.Parallel()
+
 	gs := InitGitRegoStore("https://raw.githubusercontent.com", "kubescape", "regolibrary", "releaseDev", "/", "dev", -1)
 
 	gs_tests(t, gs)
-
 }
 
 func TestGetPoliciesMethodsDevNew(t *testing.T) {
+	t.Parallel()
+
 	gs := NewDevGitRegoStore(-1)
-	err := gs.SetRegoObjects()
-	if err != nil {
-		t.Errorf("error in SetRegoObjects: %v", err)
-	}
+
+	t.Run("should set the rego store", func(t *testing.T) {
+		require.NoError(t, gs.SetRegoObjects())
+	})
+
 	gs_tests(t, gs)
 }

--- a/gitregostore/gitstoreutils.go
+++ b/gitregostore/gitstoreutils.go
@@ -397,19 +397,29 @@ func (gs *GitRegoStore) setSystemPostureExceptionPolicies(respStr string) error 
 
 func (gs *GitRegoStore) setFrameworkControlRelations(respStr string) error {
 	df := dataframe.ReadCSV(strings.NewReader(respStr))
+
+	gs.frameworkRelationsLock.Lock()
 	gs.FrameworkControlRelations = df
+	gs.frameworkRelationsLock.Unlock()
+
 	return nil
 }
 
 func (gs *GitRegoStore) setControlRuleRelations(respStr string) error {
 	df := dataframe.ReadCSV(strings.NewReader(respStr))
+
+	gs.controlRelationsLock.Lock()
 	gs.ControlRuleRelations = df
+	gs.controlRelationsLock.Unlock()
+
 	return nil
 }
 
 func (gs *GitRegoStore) lockAll() {
 	gs.frameworksLock.Lock()
 	gs.controlsLock.Lock()
+	gs.controlRelationsLock.Lock()
+	gs.frameworkRelationsLock.Lock()
 	gs.rulesLock.Lock()
 	gs.attackTracksLock.Lock()
 	gs.systemPostureExceptionPoliciesLock.Lock()
@@ -419,6 +429,8 @@ func (gs *GitRegoStore) lockAll() {
 func (gs *GitRegoStore) rLockAll() {
 	gs.frameworksLock.RLock()
 	gs.controlsLock.RLock()
+	gs.controlRelationsLock.RLock()
+	gs.frameworkRelationsLock.RLock()
 	gs.rulesLock.RLock()
 	gs.attackTracksLock.RLock()
 	gs.systemPostureExceptionPoliciesLock.RLock()
@@ -426,21 +438,27 @@ func (gs *GitRegoStore) rLockAll() {
 }
 
 func (gs *GitRegoStore) unlockAll() {
-	gs.frameworksLock.Unlock()
-	gs.controlsLock.Unlock()
-	gs.rulesLock.Unlock()
-	gs.attackTracksLock.Unlock()
-	gs.systemPostureExceptionPoliciesLock.Unlock()
+	// unlock acquired mutexes in the reverse order of locking
 	gs.DefaultConfigInputsLock.Unlock()
+	gs.systemPostureExceptionPoliciesLock.Unlock()
+	gs.attackTracksLock.Unlock()
+	gs.rulesLock.Unlock()
+	gs.frameworkRelationsLock.Unlock()
+	gs.controlRelationsLock.Unlock()
+	gs.controlsLock.Unlock()
+	gs.frameworksLock.Unlock()
 }
 
 func (gs *GitRegoStore) rUnlockAll() {
-	gs.frameworksLock.RUnlock()
-	gs.controlsLock.RUnlock()
-	gs.rulesLock.RUnlock()
-	gs.attackTracksLock.RUnlock()
-	gs.systemPostureExceptionPoliciesLock.RUnlock()
+	// unlock acquired mutexes in the reverse order of locking
 	gs.DefaultConfigInputsLock.RUnlock()
+	gs.systemPostureExceptionPoliciesLock.RUnlock()
+	gs.frameworkRelationsLock.RUnlock()
+	gs.attackTracksLock.RUnlock()
+	gs.rulesLock.RUnlock()
+	gs.controlRelationsLock.RUnlock()
+	gs.controlsLock.RUnlock()
+	gs.frameworksLock.RUnlock()
 }
 
 func (gs *GitRegoStore) copyData(other *GitRegoStore) {


### PR DESCRIPTION
This PR strengthens data access methods for the GitRegoStore, introducing new RW locks and resolving the lazy-loading problems with a lock escalation method.

* fixes #79 
* refactored unit tests