### PR TITLE
Fix(exceptions): adopted stronger hashing for cache

### DIFF
--- a/exceptions/internal/hashmap/doc.go
+++ b/exceptions/internal/hashmap/doc.go
@@ -1,0 +1,3 @@
+// Package hashmap provides a hashing function to uniquely
+// identify sets such as map[string]string.
+package hashmap

--- a/exceptions/internal/hashmap/hashmap.go
+++ b/exceptions/internal/hashmap/hashmap.go
@@ -1,0 +1,134 @@
+package hashmap
+
+import (
+	"hash/fnv"
+	"math/bits"
+	"unsafe"
+)
+
+const (
+	q       uint64 = 18446744069414584321 // some frequently used high prime number to produce finite field arithmetics modulo q
+	qInvNeg uint64 = 18446744069414584319 // q + r'.r = 1, i.e., qInvNeg = - q⁻¹ mod r
+	rSquare uint64 = 18446744065119617025 // the Montgommery constant
+)
+
+// HashMap computes a set-hash as a unique signature for the content of the input map.
+//
+// FNV64a is the unitary hash used for every (key,value) pair.
+//
+// The hash combination is based on the MSet-Mu-Hash method described in [1](https://people.csail.mit.edu/devadas/pubs/mhashes.pdf) (section 5).
+//
+// The faster MSet-XOR-Hash method has been discarded because of some extra requirements (unique nonce, equality with modulo)
+// that make it unsuitable for cache indexing.
+func HashMap(input map[string]string) uint64 {
+	if len(input) == 0 {
+		return 0
+	}
+
+	sum := uint64(1)
+	h := fnv.New64a()
+
+	for k, v := range input {
+		bk, bv := hackZeroAlloc(k, v)
+
+		// The hash is case sensitive. This shouldn't have any significant impact on performances
+		_, _ = h.Write(bk)
+		_, _ = h.Write([]byte{'0'})
+		_, _ = h.Write(bv)
+
+		// MSet-Mu-Hash: sum = sum * h.Sum64() mod q (product in finite field)
+		// NOTE: for the record with MSet-Xor-Hash, we have sum ^= h.Sum64() (with initial value 0)
+		sum = fieldMul64(sum, h.Sum64())
+		h.Reset()
+	}
+
+	return sum
+}
+
+// fieldMul64 yields x*y mod q on uint64 operands.
+//
+// From https://github.com/consensys/gnark-crypto/blob/v0.9.0/field/goldilocks/element_ops_purego.go#L59
+//
+// Also see:
+// * https://en.wikipedia.org/wiki/Montgomery_modular_multiplication
+func fieldMul64(x, y uint64) uint64 {
+	// to Montgomery form
+	x, y = tomont(x), tomont(y)
+
+	var r uint64
+
+	hi, lo := bits.Mul64(x, y)
+	if lo != 0 {
+		hi++ // x * y ≤ 2¹²⁸ - 2⁶⁵ + 1, meaning hi ≤ 2⁶⁴ - 2 so no need to worry about overflow
+	}
+
+	m := lo * qInvNeg
+	hi2, _ := bits.Mul64(m, q)
+	r, carry := bits.Add64(hi2, hi, 0)
+	if carry != 0 || r >= q {
+		r -= q // we need to reduce
+	}
+
+	// from Montgomery form
+	return frommont(r)
+}
+
+func tomont(x uint64) uint64 {
+	var r uint64
+
+	hi, lo := bits.Mul64(x, rSquare)
+	if lo != 0 {
+		hi++
+	}
+
+	m := lo * qInvNeg
+	hi2, _ := bits.Mul64(m, q)
+	r, carry := bits.Add64(hi2, hi, 0)
+	if carry != 0 || r >= q {
+		r -= q
+	}
+
+	return r
+}
+
+func frommont(x uint64) uint64 {
+	m := x * qInvNeg
+	c := madd0(m, q, x)
+	x = c
+
+	if x >= q {
+		x -= q
+	}
+
+	return x
+}
+
+// madd0 hi = a*b + c (discards lo bits)
+func madd0(a, b, c uint64) (hi uint64) {
+	var carry, lo uint64
+	hi, lo = bits.Mul64(a, b)
+	_, carry = bits.Add64(lo, c, 0)
+	hi, _ = bits.Add64(hi, 0, carry)
+	return
+}
+
+// internalString representation of a string by the golang runtime
+type internalString struct {
+	Data unsafe.Pointer
+	Len  int
+}
+
+// hackZeroAlloc reuses a common hack found in the standard library
+// to avoid allocating the underlying bytes of a string when converting.
+//
+// This assumes that the caller does not use the returned []byte slices after
+// having relinquished the input string to the garbage collector.
+func hackZeroAlloc(k, v string) ([]byte, []byte) {
+	addrK := (*internalString)(unsafe.Pointer(&k)).Data
+	bk := unsafe.Slice((*byte)(addrK), len(k))
+
+	addrV := (*internalString)(unsafe.Pointer(&v)).Data
+	bv := unsafe.Slice((*byte)(addrV), len(v))
+
+	return bv, bk
+}

--- a/exceptions/internal/hashmap/hashmap_test.go
+++ b/exceptions/internal/hashmap/hashmap_test.go
@@ -1,0 +1,129 @@
+package hashmap
+
+import (
+	"crypto/rand"
+	"log"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashCollisions(t *testing.T) {
+	// Test hashes on a large number of random map[string]string.
+	// NOTE: this test is not very powerful and can only assert gross blunders
+	// in the hash implementation. In particular, it is not large enough to
+	// compare MSet-XOR-Hash and MSet-Mu-Hash.
+	const (
+		// n      = 100000000 // This is on a local computer with a lot of memory...
+		n      = 1000 // This is for smoke-testing on CI
+		size   = 8
+		length = 4 // string lengths
+	)
+
+	hashes := make(map[uint64]map[string]string, n)
+	generator := &mapsGenerator{n: n, size: size, length: length}
+
+	for {
+		attrs := generator.Next()
+		if attrs == nil {
+			break
+		}
+
+		hash := HashMap(attrs)
+		collided, found := hashes[hash]
+		if found {
+			// verify that the maps are actually the same
+			require.EqualValues(t, collided, attrs,
+				"expected hash to be unique for different maps: found a collision: %v ~ %v", attrs, collided,
+			)
+		}
+		hashes[hash] = attrs
+	}
+
+	t.Logf("successfully compared %d hashes of random maps of size %d", n, size)
+}
+
+// mapsGenerator generate maps of "size" elements with keys and values random strings of length "length"
+type mapsGenerator struct {
+	n         int
+	size      int
+	length    int
+	generated int
+}
+
+func (g *mapsGenerator) Next() map[string]string {
+	if g.generated >= g.size {
+		return nil
+	}
+
+	result := make(map[string]string, g.size)
+	for i := 0; i < g.size; i++ {
+		key := make([]byte, g.length)
+		_, err := rand.Read(key)
+		if err != nil {
+			log.Printf("warning: random generator error: %v", err)
+			return nil
+		}
+		value := make([]byte, g.length)
+		_, err = rand.Read(value)
+		if err != nil {
+			log.Printf("warning: random generator error: %v", err)
+			return nil
+		}
+
+		result[string(key)] = string(value)
+	}
+
+	g.generated++
+
+	return result
+}
+
+func multmod(a, b uint64) uint64 {
+	// a reference implementation of a * b mod q, without any optimization
+	x := big.NewInt(0)
+	x.SetUint64(a)
+
+	y := big.NewInt(0)
+	y.SetUint64(b)
+
+	prime := big.NewInt(0)
+	prime.SetUint64(q)
+
+	z := big.NewInt(0).Mul(x, y)
+	m := big.NewInt(0).Mod(z, prime)
+	if !m.IsUint64() {
+		panic("must be representable as a uint64")
+	}
+
+	return m.Uint64()
+}
+
+func TestFieldMult(t *testing.T) {
+	operands := []uint64{ // taken from sample outputs from FNV hashes
+		4645756927087552409,
+		16162368515513178030,
+		18164748899638307352,
+		10422122549694193689,
+		17734110399310544832,
+		1972183573942468894,
+		13759071485432025751,
+		11592539056557247347,
+	}
+
+	for i, a := range operands {
+		var b uint64
+		if i == len(operands)-1 {
+			b = operands[0]
+		} else {
+			b = operands[i+1]
+		}
+
+		p1 := multmod(a, b)
+		p2 := fieldMul64(a, b)
+		require.Equalf(t, p1, p2,
+			"expected %d x %d mod %d = %d but got %d", a, b, q, p1, p2,
+		)
+	}
+}


### PR DESCRIPTION
This PR is a follow-up on #75 (intent: caching results from the exception processor).

It adopts a more robust hashing method to summarize the map in attributesDesignators:
the naive commutative mashing proposed by #75 is more likely to produce collisions.

The newly proposed method implements a cryptographic hash with more thoroughly researched resistance to collisions (https://people.csail.mit.edu/devadas/pubs/mhashes.pdf, MSet-Mu-Hash method). The hash remains fast to compute.

* fixes #86 