### PR TITLE
Fixed GetStatus and GetSubStatus (old reports)

### DIFF
--- a/reporthandling/results/v1/resourcesresults/testdata/new_resource_associated_controls.json
+++ b/reporthandling/results/v1/resourcesresults/testdata/new_resource_associated_controls.json
@@ -1,0 +1,85 @@
+[
+    {
+        "controlID": "C-0053",
+        "name": "Access container service account",
+        "status": {
+            "status": "passed"
+        },
+        "subStatus": "w/exceptions",
+        "rules": [
+            {
+                "name": "access-container-service-account-v1",
+                "status": "passed",
+                "subStatus": "w/exceptions",
+                "exception": [
+                    {
+                        "guid": "",
+                        "name": "exclude-kube-system-service-accounts-20",
+                        "attributes": {
+                            "systemException": true
+                        },
+                        "policyType": "postureExceptionPolicy",
+                        "creationTime": "",
+                        "actions": [
+                            "alertOnly"
+                        ],
+                        "resources": [
+                            {
+                                "designatorType": "Attributes",
+                                "attributes": {
+                                    "kind": "ServiceAccount",
+                                    "name": "ephemeral-volume-controller",
+                                    "namespace": "kube-system"
+                                }
+                            }
+                        ],
+                        "posturePolicies": [
+                            {
+                                "frameworkName": ""
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "controlID": "C-0014",
+        "name": "Access Kubernetes dashboard",
+        "status": {
+            "status": "passed"
+        },
+        "subStatus": "",
+        "rules": [
+            {
+                "name": "rule-access-dashboard-subject-v1",
+                "status": "passed",
+                "subStatus": ""
+            }
+        ]
+    },
+    {
+        "controlID": "C-0212",
+        "name": "CIS-5.7.4 The default namespace should not be used",
+        "status": {
+            "status": "failed"
+        },
+        "subStatus": "",
+        "rules": [
+            {
+                "name": "resources-notpods-in-default-namespace",
+                "status": "failed",
+                "subStatus": "",
+                "paths": [
+                    {
+                        "failedPath": "metadata.namespace",
+                        "fixPath": {
+                            "path": "",
+                            "value": ""
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/reporthandling/results/v1/resourcesresults/testdata/old_resource_associated_controls.json
+++ b/reporthandling/results/v1/resourcesresults/testdata/old_resource_associated_controls.json
@@ -1,0 +1,96 @@
+[
+    {
+        "controlID": "C-0054",
+        "name": "Cluster internal networking",
+        "rules": [
+            {
+                "name": "internal-networking",
+                "status": "failed",
+                "exception": [
+                    {
+                        "guid": "",
+                        "name": "exclude-minikube-kube-system-resources-6",
+                        "attributes": {
+                            "systemException": true
+                        },
+                        "policyType": "postureExceptionPolicy",
+                        "creationTime": "",
+                        "actions": [
+                            "alertOnly"
+                        ],
+                        "resources": [
+                            {
+                                "designatorType": "Attributes",
+                                "attributes": {
+                                    "kind": "Namespace",
+                                    "name": "kube-system"
+                                }
+                            }
+                        ],
+                        "posturePolicies": [
+                            {
+                                "frameworkName": "",
+                                "controlID": "C-.*"
+                            }
+                        ]
+                    },
+                    {
+                        "guid": "",
+                        "name": "exclude-aks-kube-system-namespaces-1",
+                        "attributes": {
+                            "systemException": true
+                        },
+                        "policyType": "postureExceptionPolicy",
+                        "creationTime": "",
+                        "actions": [
+                            "alertOnly"
+                        ],
+                        "resources": [
+                            {
+                                "designatorType": "Attributes",
+                                "attributes": {
+                                    "kind": "Namespace",
+                                    "name": "kube-system"
+                                }
+                            }
+                        ],
+                        "posturePolicies": [
+                            {
+                                "frameworkName": ""
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "controlID": "C-0067",
+        "name": "Audit logs enabled",
+        "rules": [
+            {
+                "name": "k8s-audit-logs-enabled-native",
+                "status": "failed",
+                "paths": [
+                    {
+                        "failedPath": "spec.containers[0].command",
+                        "fixPath": {
+                            "path": "",
+                            "value": ""
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "controlID": "C-0002",
+        "name": "Exec into container",
+        "rules": [
+            {
+                "name": "exec-into-container-v1",
+                "status": "passed"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Fixed GetStatus and GetSubStatus for ResourceAssociatedControls of old reports

We identify old ResourceAssociatedControl by having empty status fields, because in the old flow the SetStatus was not called on the RAC. If that's the case, we run the calculation on the fly.
