### PR TITLE
support SummaryDetails risk score for backward compatibility

### DIFF
--- a/reporthandling/results/v1/reportsummary/datastructures.go
+++ b/reporthandling/results/v1/reportsummary/datastructures.go
@@ -21,6 +21,7 @@ type SummaryDetails struct {
 	ControlsSeverityCounters  SeverityCounters    `json:"controlsSeverityCounters,omitempty"`
 	StatusCounters            StatusCounters      `json:"ResourceCounters"` // Backward compatibility
 	Score                     float32             `json:"score"`
+	ComplianceScore           float32             `json:"complianceScore"`
 }
 
 // FrameworkSummary summary of scanning from a single framework perspective

--- a/reporthandling/v2/datastructures.go
+++ b/reporthandling/v2/datastructures.go
@@ -108,17 +108,18 @@ type ScanMetadata struct {
 	// `Formats` field instead.
 	Format string `json:"format,omitempty"`
 	// Formats that have been requested for the output results.
-	Formats            []string       `json:"formats,omitempty"`
-	UseExceptions      string         `json:"useExceptions,omitempty"`
-	Logger             string         `json:"logger,omitempty"`
-	ExcludedNamespaces []string       `json:"excludedNamespaces,omitempty"`
-	IncludeNamespaces  []string       `json:"includeNamespaces,omitempty"`
-	TargetNames        []string       `json:"targetNames,omitempty"`
-	FailThreshold      float32        `json:"failThreshold,omitempty"`
-	ScanningTarget     ScanningTarget `json:"scanningTarget,omitempty"`
-	HostScanner        bool           `json:"hostScanner,omitempty"`
-	Submit             bool           `json:"submit,omitempty"`
-	VerboseMode        bool           `json:"verboseMode,omitempty"`
+	Formats             []string       `json:"formats,omitempty"`
+	UseExceptions       string         `json:"useExceptions,omitempty"`
+	Logger              string         `json:"logger,omitempty"`
+	ExcludedNamespaces  []string       `json:"excludedNamespaces,omitempty"`
+	IncludeNamespaces   []string       `json:"includeNamespaces,omitempty"`
+	TargetNames         []string       `json:"targetNames,omitempty"`
+	FailThreshold       float32        `json:"failThreshold,omitempty"`
+	ComplianceThreshold float32        `json:"complianceThreshold,omitempty"`
+	ScanningTarget      ScanningTarget `json:"scanningTarget,omitempty"`
+	HostScanner         bool           `json:"hostScanner,omitempty"`
+	Submit              bool           `json:"submit,omitempty"`
+	VerboseMode         bool           `json:"verboseMode,omitempty"`
 }
 
 // Moved to apis/cloudmetadata.go

--- a/score/score.go
+++ b/score/score.go
@@ -352,10 +352,10 @@ func max32(a, b float32) float32 {
 
 // SetPostureReportComplianceScores calculates and populates scores for all controls, frameworks and whole scan.
 func (su *ScoreUtil) SetPostureReportComplianceScores(report *v2.PostureReport) error {
-	// call CalculatePostureReportV2 to set frameworks.score for backward compatibility
-	// afterwards we will override the controls.score and summeryDetails.score
-	// and set frameworks.complianceScore
-	// TODO: remove CalculatePostureReportV2 call after we deprecate frameworks.score
+	// call CalculatePostureReportV2 to set frameworks.score and summaryDetails.score for backward compatibility
+	// afterwards we will override the controls.score
+	// and set frameworks.complianceScore and summaryDetails.complianceScore
+	// TODO: remove CalculatePostureReportV2 call after we deprecate frameworks.score and summaryDetails.score
 	if err := su.CalculatePostureReportV2(report); err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func (su *ScoreUtil) SetPostureReportComplianceScores(report *v2.PostureReport) 
 	if len(report.SummaryDetails.Controls) > 0 {
 		summaryScore = sumScore / float32(len(report.SummaryDetails.Controls))
 	}
-	report.SummaryDetails.Score = summaryScore
+	report.SummaryDetails.ComplianceScore = summaryScore
 	return nil
 }
 

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -945,7 +945,7 @@ func TestSetPostureReportComplianceScores(t *testing.T) {
 		})
 
 		t.Run("assert final score", func(t *testing.T) {
-			assert.InDeltaf(t, expectedSummary, report.SummaryDetails.Score, 1e-6,
+			assert.InDeltaf(t, expectedSummary, report.SummaryDetails.ComplianceScore, 1e-6,
 				"unexpected summarized final score",
 			)
 		})


### PR DESCRIPTION
Added new field `complianceScore` to SummaryDetails so we can continue supporting risk score in `score` field