### PR TITLE
Add complianceScore field to ControlSummary

### DIFF
--- a/objectsenvelopes/objectshandler_test.go
+++ b/objectsenvelopes/objectshandler_test.go
@@ -1,0 +1,107 @@
+package objectsenvelopes
+
+import (
+	"testing"
+
+	cloudsupportv1 "github.com/kubescape/k8s-interface/cloudsupport/v1"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/objectsenvelopes/hostsensor"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewObject(t *testing.T) {
+	// Test nil input
+	assert.Nil(t, NewObject(nil))
+
+	// Test valid input
+	object := map[string]interface{}{
+		"kind":       "Pod",
+		"apiVersion": "v1",
+		"metadata": map[string]interface{}{
+			"name": "test-pod",
+		},
+	}
+	workloadObj := NewObject(object)
+	assert.NotNil(t, workloadObj)
+	assert.Equal(t, "Pod", workloadObj.GetKind())
+
+	// Test unsupported input
+	unsupportedObject := map[string]interface{}{
+		"unknown": "unknown",
+	}
+	assert.Nil(t, NewObject(unsupportedObject))
+}
+
+func TestGetObjectType(t *testing.T) {
+	// Test unsupported input
+	unsupportedObject := map[string]interface{}{
+		"unknown": "unknown",
+	}
+	assert.Equal(t, workloadinterface.TypeUnknown, GetObjectType(unsupportedObject))
+
+	// Test RegoResponseVectorObject
+	relatedObjects := []map[string]interface{}{}
+	relatedObject := getMock(role)
+	relatedObject2 := getMock(rolebinding)
+	relatedObjects = append(relatedObjects, relatedObject)
+	relatedObjects = append(relatedObjects, relatedObject2)
+	subject := map[string]interface{}{"name": "user@example.com", "kind": "User", "namespace": "default", "group": "rbac.authorization.k8s.io", RelatedObjectsKey: relatedObjects}
+	assert.Equal(t, TypeRegoResponseVectorObject, GetObjectType(subject))
+
+	// Test CloudProviderDescribe
+	cloudProviderDescribe := map[string]interface{}{
+		"apiVersion": "container.googleapis.com/v1",
+		"kind":       "ClusterDescribe",
+	}
+	assert.Equal(t, cloudsupportv1.TypeCloudProviderDescribe, GetObjectType(cloudProviderDescribe))
+
+	// Test HostSensor
+	hostSensor := map[string]interface{}{
+		"apiVersion": "hostdata.kubescape.cloud/v1",
+		"metadata": map[string]interface{}{
+			"name": "test-pod",
+		},
+	}
+	assert.Equal(t, hostsensor.TypeHostSensor, GetObjectType(hostSensor))
+
+	// Test LocalWorkload
+	localWorkload := map[string]interface{}{
+		"kind":       "b",
+		"sourcePath": "/path/file",
+	}
+	assert.Equal(t, localworkload.TypeLocalWorkload, GetObjectType(localWorkload))
+
+	// Test WorkloadObject
+	workloadObject := map[string]interface{}{
+		"kind":       "Pod",
+		"apiVersion": "v1",
+		"metadata": map[string]interface{}{
+			"name": "test-pod",
+		},
+	}
+	assert.Equal(t, workloadinterface.TypeWorkloadObject, GetObjectType(workloadObject))
+
+	// Test ListWorkloads
+	listWorkloads := map[string]interface{}{
+		"kind": "List",
+		"items": []interface{}{
+			map[string]interface{}{
+				"kind": "Pod",
+				"metadata": map[string]interface{}{
+					"name": "test-pod",
+				},
+			},
+		},
+	}
+	assert.Equal(t, workloadinterface.TypeListWorkloads, GetObjectType(listWorkloads))
+}
+
+// // Test BaseObject
+// baseObject := map[string]interface{}{
+// 	"kind": "Pod",
+// 	"metadata": map[string]interface{}{
+// 		"name": "test-pod",
+// 	},
+// }
+// assert.Equal(t

--- a/objectsenvelopes/objectshandler_test.go
+++ b/objectsenvelopes/objectshandler_test.go
@@ -96,12 +96,3 @@ func TestGetObjectType(t *testing.T) {
 	}
 	assert.Equal(t, workloadinterface.TypeListWorkloads, GetObjectType(listWorkloads))
 }
-
-// // Test BaseObject
-// baseObject := map[string]interface{}{
-// 	"kind": "Pod",
-// 	"metadata": map[string]interface{}{
-// 		"name": "test-pod",
-// 	},
-// }
-// assert.Equal(t

--- a/reporthandling/results/v1/reportsummary/controlsummarymethods.go
+++ b/reporthandling/results/v1/reportsummary/controlsummarymethods.go
@@ -116,6 +116,14 @@ func (controlSummary *ControlSummary) GetScore() float32 {
 	return controlSummary.Score
 }
 
+func (controlSummary *ControlSummary) GetComplianceScore() float32 {
+	// if ComplianceScore field is set return it, else return -1
+	if controlSummary.ComplianceScore != nil {
+		return *controlSummary.ComplianceScore
+	}
+	return -1
+}
+
 // GetScoreFactor return control score
 func (controlSummary *ControlSummary) GetScoreFactor() float32 {
 	return controlSummary.ScoreFactor

--- a/reporthandling/results/v1/reportsummary/datastructures.go
+++ b/reporthandling/results/v1/reportsummary/datastructures.go
@@ -47,6 +47,7 @@ type ControlSummary struct {
 	StatusCounters    StatusCounters      `json:"ResourceCounters"` // Backward compatibility
 	SubStatusCounters SubStatusCounters   `json:"subStatusCounters"`
 	Score             float32             `json:"score"`
+	ComplianceScore   *float32            `json:"complianceScore,omitempty"`
 	ScoreFactor       float32             `json:"scoreFactor"`
 }
 

--- a/reporthandling/results/v1/reportsummary/interface.go
+++ b/reporthandling/results/v1/reportsummary/interface.go
@@ -69,6 +69,9 @@ type IPolicies interface {
 	// Score
 	GetScore() float32
 
+	// ComplianceScore
+	GetComplianceScore() float32
+
 	// Name
 	GetName() string
 }

--- a/score/score.go
+++ b/score/score.go
@@ -403,6 +403,11 @@ func (su *ScoreUtil) GetFrameworkComplianceScore(framework *reportsummary.Framew
 
 // GetControlComplianceScore returns the compliance score for a given control (as a percentage).
 func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummary, _ /*frameworkName*/ string) float32 {
+	// If a control has status passed it should always be considered as having 100% compliance score
+	if ctrl.GetStatus().IsPassed() {
+		return 100
+	}
+
 	resourcesIDs := ctrl.ListResourcesIDs()
 	passedResourceIDS := resourcesIDs.Passed()
 	allResourcesIDSIter := resourcesIDs.All()
@@ -425,12 +430,6 @@ func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummar
 
 	if numOfAllResources > 0 {
 		return (numOfPassedResources / numOfAllResources) * 100
-	}
-
-	// in case the control didn't run on any resources:
-	// If the control passed (irrelevant): score = 100 , else (skipped): score = 0
-	if ctrl.GetStatus().IsPassed() {
-		return 100
 	}
 	return 0
 }

--- a/score/score.go
+++ b/score/score.go
@@ -425,7 +425,13 @@ func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummar
 	if numOfAllResources > 0 {
 		ctrlScore = (numOfPassedResources / numOfAllResources) * 100
 	} else {
-		logger.L().Debug("no resources were given for this control, score is 0", helpers.String("controlID", ctrl.GetID()))
+		// in case the control didn't run on any resources:
+		// If the control passed (irrelevant): score = 100 , else (skipped): score = 0
+		if ctrl.GetStatus().IsPassed() {
+			ctrlScore = 100
+		} else {
+			logger.L().Debug("no resources were given for this control, score is 0", helpers.String("controlID", ctrl.GetID()))
+		}
 	}
 
 	return ctrlScore

--- a/score/score.go
+++ b/score/score.go
@@ -432,6 +432,5 @@ func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummar
 	if ctrl.GetStatus().IsPassed() {
 		return 100
 	}
-	logger.L().Debug("no resources were given for this control, score is 0", helpers.String("controlID", ctrl.GetID()))
 	return 0
 }

--- a/score/score.go
+++ b/score/score.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/kubescape/opa-utils/reporthandling/results/v1/reportsummary"
 	v2 "github.com/kubescape/opa-utils/reporthandling/v2"
+	"github.com/kubescape/opa-utils/shared"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 )
@@ -351,8 +352,7 @@ func max32(a, b float32) float32 {
 // SetPostureReportComplianceScores calculates and populates scores for all controls, frameworks and whole scan.
 func (su *ScoreUtil) SetPostureReportComplianceScores(report *v2.PostureReport) error {
 	// call CalculatePostureReportV2 to set frameworks.score and summaryDetails.score for backward compatibility
-	// afterwards we will override the controls.score
-	// and set frameworks.complianceScore and summaryDetails.complianceScore
+	// afterwards we set complianceScore for frameworks, controls and summaryDetails
 	// TODO: remove CalculatePostureReportV2 call after we deprecate frameworks.score and summaryDetails.score
 	if err := su.CalculatePostureReportV2(report); err != nil {
 		return err
@@ -378,10 +378,9 @@ func (su *ScoreUtil) SetPostureReportComplianceScores(report *v2.PostureReport) 
 func (su *ScoreUtil) ControlsSummariesComplianceScore(ctrls *reportsummary.ControlSummaries, frameworkName string) (sumScore float32) {
 	for ctrlID := range *ctrls {
 		ctrl := (*ctrls)[ctrlID]
-		ctrl.Score = 0
-		ctrl.Score = su.GetControlComplianceScore(&ctrl, frameworkName)
+		ctrl.ComplianceScore = shared.Ptr(su.GetControlComplianceScore(&ctrl, frameworkName))
 		(*ctrls)[ctrlID] = ctrl
-		sumScore += ctrl.GetScore()
+		sumScore += ctrl.GetComplianceScore()
 	}
 	return sumScore
 }

--- a/score/score.go
+++ b/score/score.go
@@ -392,7 +392,8 @@ func (su *ScoreUtil) ControlsSummariesComplianceScore(ctrls *reportsummary.Contr
 
 // GetFrameworkComplianceScore returns the compliance score for a given framework (as a percentage)
 // The framework compliance score is the average of all controls scores in that framework
-func (su *ScoreUtil) GetFrameworkComplianceScore(framework *reportsummary.FrameworkSummary) (frameworkScore float32) {
+func (su *ScoreUtil) GetFrameworkComplianceScore(framework *reportsummary.FrameworkSummary) float32 {
+	frameworkScore := float32(0)
 	sumScore := su.ControlsSummariesComplianceScore(&framework.Controls, framework.GetName())
 	if len(framework.Controls) > 0 {
 		frameworkScore = sumScore / float32(len(framework.Controls))
@@ -401,7 +402,7 @@ func (su *ScoreUtil) GetFrameworkComplianceScore(framework *reportsummary.Framew
 }
 
 // GetControlComplianceScore returns the compliance score for a given control (as a percentage).
-func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummary, _ /*frameworkName*/ string) (ctrlScore float32) {
+func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummary, _ /*frameworkName*/ string) float32 {
 	resourcesIDs := ctrl.ListResourcesIDs()
 	passedResourceIDS := resourcesIDs.Passed()
 	allResourcesIDSIter := resourcesIDs.All()
@@ -423,16 +424,14 @@ func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummar
 	}
 
 	if numOfAllResources > 0 {
-		ctrlScore = (numOfPassedResources / numOfAllResources) * 100
-	} else {
-		// in case the control didn't run on any resources:
-		// If the control passed (irrelevant): score = 100 , else (skipped): score = 0
-		if ctrl.GetStatus().IsPassed() {
-			ctrlScore = 100
-		} else {
-			logger.L().Debug("no resources were given for this control, score is 0", helpers.String("controlID", ctrl.GetID()))
-		}
+		return (numOfPassedResources / numOfAllResources) * 100
 	}
 
-	return ctrlScore
+	// in case the control didn't run on any resources:
+	// If the control passed (irrelevant): score = 100 , else (skipped): score = 0
+	if ctrl.GetStatus().IsPassed() {
+		return 100
+	}
+	logger.L().Debug("no resources were given for this control, score is 0", helpers.String("controlID", ctrl.GetID()))
+	return 0
 }

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -814,6 +814,46 @@ func TestGetControlComplianceScore(t *testing.T) {
 		)
 	})
 
+	t.Run("skipped control", func(t *testing.T) {
+		t.Parallel()
+
+		resources := mockResources(t)
+		s := ScoreUtil{isDebugMode: true, resources: resources}
+		controlReport := reportsummary.ControlSummary{
+			Name:      "skipped-control",
+			ControlID: "skipped1",
+			StatusInfo: apis.StatusInfo{
+				InnerInfo:   "enable-host-scan flag not used. For more information: https://hub.armosec.io/docs/host-sensor",
+				InnerStatus: "skipped",
+			},
+			ResourceIDs: helpers.AllLists{},
+		}
+
+		require.Equal(t, float32(0), s.GetControlComplianceScore(&controlReport, ""),
+			"skipped control report should return a score equals to 0",
+		)
+	})
+
+	t.Run("passed (irrelevant) control", func(t *testing.T) {
+		t.Parallel()
+
+		resources := mockResources(t)
+		s := ScoreUtil{isDebugMode: true, resources: resources}
+		controlReport := reportsummary.ControlSummary{
+			Name:      "irrelevant-control",
+			ControlID: "irrelevant1",
+			StatusInfo: apis.StatusInfo{
+				SubStatus:   "irrelevant",
+				InnerStatus: "passed",
+			},
+			ResourceIDs: helpers.AllLists{},
+		}
+
+		require.Equal(t, float32(100), s.GetControlComplianceScore(&controlReport, ""),
+			"passed (irrelevant) control report should return a score equals to 100",
+		)
+	})
+
 	t.Run("with control report", func(t *testing.T) {
 		t.Parallel()
 

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -947,20 +947,29 @@ func TestSetPostureReportComplianceScores(t *testing.T) {
 		t.Run("assert control scores", func(t *testing.T) {
 			require.Len(t, report.SummaryDetails.Controls, 4)
 			for _, control := range report.SummaryDetails.Controls {
-				var expectedForControl float64
+				var expectedComplianceScore float64
+				var expectedScore float64
 
 				switch control.ControlID {
 				case "control-1":
-					expectedForControl = 33.333336
+					expectedComplianceScore = 33.333336
+					expectedScore = 81.13208
 				case "control-2":
-					expectedForControl = 100 // passed
+					expectedComplianceScore = 100 // passed
+					expectedScore = 0
 				case "control-3":
-					expectedForControl = 50
+					expectedComplianceScore = 50
+					expectedScore = 66.666664
 				case "control-4":
-					expectedForControl = 100 // passed
+					expectedComplianceScore = 100 // passed
+					expectedScore = 0
 				}
 
-				assert.InDeltaf(t, expectedForControl, control.Score, 1e-6,
+				assert.InDeltaf(t, expectedComplianceScore, *control.ComplianceScore, 1e-6,
+					"unexpected summarized score for control %q", control.ControlID,
+				)
+				// check that control score wasn't overridden by compliance score
+				assert.InDeltaf(t, expectedScore, control.Score, 1e-6,
 					"unexpected summarized score for control %q", control.ControlID,
 				)
 			}

--- a/shared/pointer.go
+++ b/shared/pointer.go
@@ -1,0 +1,5 @@
+package shared
+
+func Ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
`complianceScore` field was added to ControlSummary as a pointer so that it will not get 0 as a default value, which is a valid compliance score value for a control.