### PR TITLE
fix statuses - requires review and requires configurations

### DIFF
--- a/reporthandling/results/v1/reportsummary/controlsummarymethods.go
+++ b/reporthandling/results/v1/reportsummary/controlsummarymethods.go
@@ -68,13 +68,15 @@ func (controlSummary *ControlSummary) calculateNSetSubStatus(subStatus apis.Scan
 		} else if subStatus == apis.SubStatusManualReview || controlSummary.StatusInfo.SubStatus == apis.SubStatusManualReview {
 			controlSummary.StatusInfo.SubStatus = apis.SubStatusManualReview
 			controlSummary.StatusInfo.InnerInfo = string(apis.SubStatusManualReviewInfo)
-		} else if subStatus == apis.SubStatusRequiresReview || controlSummary.StatusInfo.SubStatus == apis.SubStatusRequiresReview {
-			controlSummary.StatusInfo.SubStatus = apis.SubStatusRequiresReview
-			controlSummary.StatusInfo.InnerInfo = string(apis.SubStatusRequiresReviewInfo)
 		}
 	case apis.StatusFailed:
-		controlSummary.StatusInfo.SubStatus = apis.SubStatusUnknown
-		controlSummary.StatusInfo.InnerInfo = ""
+		if subStatus == apis.SubStatusRequiresReview || controlSummary.StatusInfo.SubStatus == apis.SubStatusRequiresReview {
+			controlSummary.StatusInfo.SubStatus = apis.SubStatusRequiresReview
+			controlSummary.StatusInfo.InnerInfo = string(apis.SubStatusRequiresReviewInfo)
+		} else {
+			controlSummary.StatusInfo.SubStatus = apis.SubStatusUnknown
+			controlSummary.StatusInfo.InnerInfo = ""
+		}
 	}
 }
 

--- a/reporthandling/results/v1/reportsummary/summarydetails_test.go
+++ b/reporthandling/results/v1/reportsummary/summarydetails_test.go
@@ -174,9 +174,9 @@ func TestUpdateControlsSummaryCountersRequiresReview(t *testing.T) {
 	updateControlsSummaryCounters(&mockResultRequiresReview, controls, nil)
 	for _, v := range controls {
 		assert.Equal(t, 1, v.NumberOfResources().All())
-		assert.Equal(t, 0, v.NumberOfResources().Failed())
+		assert.Equal(t, 1, v.NumberOfResources().Failed())
 		assert.Equal(t, 0, v.NumberOfResources().Passed())
-		assert.Equal(t, 1, v.NumberOfResources().Skipped())
+		assert.Equal(t, 0, v.NumberOfResources().Skipped())
 		assert.Equal(t, apis.SubStatusRequiresReview, v.GetSubStatus())
 	}
 }

--- a/reporthandling/results/v1/resourcesresults/controls.go
+++ b/reporthandling/results/v1/resourcesresults/controls.go
@@ -120,22 +120,6 @@ func (control *ResourceAssociatedControl) ListRules() []ResourceAssociatedRule {
 	return control.ResourceAssociatedRules
 }
 
-// DEPRECATED
-// controlMissingConfiguration return true if the control is missing configuration
-func controlMissingConfiguration(control *ResourceAssociatedControl) bool {
-	for _, rule := range control.ResourceAssociatedRules {
-		if len(rule.ControlConfigurations) == 0 {
-			return true
-		}
-		for _, configuration := range rule.ControlConfigurations {
-			if len(configuration) == 0 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // controlMissingConfiguration returns true if all control configurations are missing
 func controlMissingAllConfigurations(control *ResourceAssociatedControl) bool {
 	for _, rule := range control.ResourceAssociatedRules {

--- a/reporthandling/results/v1/resourcesresults/controls.go
+++ b/reporthandling/results/v1/resourcesresults/controls.go
@@ -87,10 +87,10 @@ func (control *ResourceAssociatedControl) SetStatus(c reporthandling.Control) {
 		return
 	}
 
-	// If the control type is requires review, the status is skipped and the sub status is requires review
+	// If the control type is requires review, the status is failed and the sub status is requires review
 	actionRequired := apis.ScanningSubStatus(actionRequiredStr)
 	if status == apis.StatusFailed && actionRequired == apis.SubStatusRequiresReview {
-		status = apis.StatusSkipped
+		status = apis.StatusFailed
 		subStatus = apis.SubStatusRequiresReview
 		statusInfo = string(apis.SubStatusRequiresReviewInfo)
 	}
@@ -103,7 +103,7 @@ func (control *ResourceAssociatedControl) SetStatus(c reporthandling.Control) {
 	}
 
 	// If the control type is configuration and the configuration is not set, the status is skipped and the sub status is configuration
-	if actionRequired == apis.SubStatusConfiguration && controlMissingConfiguration(control) {
+	if actionRequired == apis.SubStatusConfiguration && controlMissingAllConfigurations(control) {
 		status = apis.StatusSkipped
 		subStatus = apis.SubStatusConfiguration
 		statusInfo = string(apis.SubStatusConfigurationInfo)
@@ -120,6 +120,7 @@ func (control *ResourceAssociatedControl) ListRules() []ResourceAssociatedRule {
 	return control.ResourceAssociatedRules
 }
 
+// DEPRECATED
 // controlMissingConfiguration return true if the control is missing configuration
 func controlMissingConfiguration(control *ResourceAssociatedControl) bool {
 	for _, rule := range control.ResourceAssociatedRules {
@@ -133,4 +134,19 @@ func controlMissingConfiguration(control *ResourceAssociatedControl) bool {
 		}
 	}
 	return false
+}
+
+// controlMissingConfiguration returns true if all control configurations are missing
+func controlMissingAllConfigurations(control *ResourceAssociatedControl) bool {
+	for _, rule := range control.ResourceAssociatedRules {
+		if len(rule.ControlConfigurations) == 0 {
+			return true
+		}
+		for _, configuration := range rule.ControlConfigurations {
+			if len(configuration) != 0 {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/reporthandling/results/v1/resourcesresults/controls_test.go
+++ b/reporthandling/results/v1/resourcesresults/controls_test.go
@@ -61,11 +61,11 @@ func TestSetStatus(t *testing.T) {
 
 	r6 := mockResourceAssociatedControlFailed()
 	r6.SetStatus(*mockControlWithActionRequiredRequiresReview())
-	assert.Equal(t, apis.StatusSkipped, r6.GetStatus(nil).Status())
+	assert.Equal(t, apis.StatusFailed, r6.GetStatus(nil).Status())
 	assert.Equal(t, apis.SubStatusRequiresReview, r6.GetSubStatus())
 	assert.False(t, r6.GetStatus(nil).IsPassed())
-	assert.False(t, r6.GetStatus(nil).IsFailed())
-	assert.True(t, r6.GetStatus(nil).IsSkipped())
+	assert.True(t, r6.GetStatus(nil).IsFailed())
+	assert.False(t, r6.GetStatus(nil).IsSkipped())
 
 }
 

--- a/reporthandling/results/v1/resourcesresults/controls_test.go
+++ b/reporthandling/results/v1/resourcesresults/controls_test.go
@@ -162,3 +162,73 @@ func Test_GetStatusAndSubStatus_NewResourceAssociatedControls(t *testing.T) {
 		assert.Equal(t, controlIdToExpectedSubStatus[control.ControlID], string(control.GetSubStatus()))
 	}
 }
+
+func TestControlMissingAllConfigurations(t *testing.T) {
+	tests := []struct {
+		name    string
+		control *ResourceAssociatedControl
+		want    bool
+	}{
+		{
+			name: "TestControlNoConfigurations",
+			control: &ResourceAssociatedControl{
+				ResourceAssociatedRules: []ResourceAssociatedRule{
+					{
+						ControlConfigurations: map[string][]string{},
+					},
+				},
+			},
+			want: true,
+		}, {
+			name: "TestControlOneEmptyConfiguration",
+			control: &ResourceAssociatedControl{
+				ResourceAssociatedRules: []ResourceAssociatedRule{
+					{
+						ControlConfigurations: map[string][]string{
+							"EmptyConfiguration": {},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "TestControlOneNonEmptyConfiguration",
+			control: &ResourceAssociatedControl{
+				ResourceAssociatedRules: []ResourceAssociatedRule{
+					{
+						ControlConfigurations: map[string][]string{
+							"NonEmptyConfiguration": {
+								"key", "value",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "TestControlMultipleConfigurations",
+			control: &ResourceAssociatedControl{
+				ResourceAssociatedRules: []ResourceAssociatedRule{
+					{
+						ControlConfigurations: map[string][]string{
+							"EmptyConfiguration": {},
+							"NonEmptyConfiguration": {
+								"key", "value",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := controlMissingAllConfigurations(tt.control); got != tt.want {
+				t.Errorf("Control.missingAllConfigurations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR changes the behaviour of two statuses:
1. configurations required - this status will now appear only if there are no configured lists at all (previous behavior - appears if one of the lists isn't configured).
2. requires review - this statuses purpose it to mark failed resources as requires review to indicate to the user that we are returning a resource that we didn't run a specific test on, they need to review it themselves. Therefore this status was moved to be the subStatus of `failed` status (previous behaviour - it was a subStatus of `skipped`)