### PR TITLE
fix configuration status

### DIFF
--- a/reporthandling/results/v1/resourcesresults/controls.go
+++ b/reporthandling/results/v1/resourcesresults/controls.go
@@ -103,7 +103,7 @@ func (control *ResourceAssociatedControl) SetStatus(c reporthandling.Control) {
 	}
 
 	// If the control type is configuration and the configuration is not set, the status is skipped and the sub status is configuration
-	if actionRequired == apis.SubStatusConfiguration && controlMissingConfiguration(control) {
+	if actionRequired == apis.SubStatusConfiguration && controlMissingAllConfigurations(control) {
 		status = apis.StatusSkipped
 		subStatus = apis.SubStatusConfiguration
 		statusInfo = string(apis.SubStatusConfigurationInfo)
@@ -120,17 +120,17 @@ func (control *ResourceAssociatedControl) ListRules() []ResourceAssociatedRule {
 	return control.ResourceAssociatedRules
 }
 
-// controlMissingConfiguration return true if the control is missing configuration
-func controlMissingConfiguration(control *ResourceAssociatedControl) bool {
+// controlMissingAllConfiguration returns true if all control configurations are missing
+func controlMissingAllConfigurations(control *ResourceAssociatedControl) bool {
 	for _, rule := range control.ResourceAssociatedRules {
 		if len(rule.ControlConfigurations) == 0 {
 			return true
 		}
 		for _, configuration := range rule.ControlConfigurations {
-			if len(configuration) == 0 {
-				return true
+			if len(configuration) != 0 {
+				return false
 			}
 		}
 	}
-	return false
+	return true
 }

--- a/reporthandling/results/v1/resourcesresults/controls_test.go
+++ b/reporthandling/results/v1/resourcesresults/controls_test.go
@@ -162,3 +162,73 @@ func Test_GetStatusAndSubStatus_NewResourceAssociatedControls(t *testing.T) {
 		assert.Equal(t, controlIdToExpectedSubStatus[control.ControlID], string(control.GetSubStatus()))
 	}
 }
+
+func TestControlMissingAllConfigurations(t *testing.T) {
+	tests := []struct {
+		name    string
+		control *ResourceAssociatedControl
+		want    bool
+	}{
+		{
+			name: "TestControlNoConfigurations",
+			control: &ResourceAssociatedControl{
+				ResourceAssociatedRules: []ResourceAssociatedRule{
+					{
+						ControlConfigurations: map[string][]string{},
+					},
+				},
+			},
+			want: true,
+		}, {
+			name: "TestControlOneEmptyConfiguration",
+			control: &ResourceAssociatedControl{
+				ResourceAssociatedRules: []ResourceAssociatedRule{
+					{
+						ControlConfigurations: map[string][]string{
+							"EmptyConfiguration": {},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "TestControlOneNonEmptyConfiguration",
+			control: &ResourceAssociatedControl{
+				ResourceAssociatedRules: []ResourceAssociatedRule{
+					{
+						ControlConfigurations: map[string][]string{
+							"NonEmptyConfiguration": {
+								"key", "value",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "TestControlMultipleConfigurations",
+			control: &ResourceAssociatedControl{
+				ResourceAssociatedRules: []ResourceAssociatedRule{
+					{
+						ControlConfigurations: map[string][]string{
+							"EmptyConfiguration": {},
+							"NonEmptyConfiguration": {
+								"key", "value",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := controlMissingAllConfigurations(tt.control); got != tt.want {
+				t.Errorf("Control.missingAllConfigurations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Changed behavior of requires configuration status according to new [requirements](https://cyberarmor-io.atlassian.net/browse/SUB-769?atlOrigin=eyJpIjoiMDE1MDQ3MDc2ZjI0NGEwODg0ODQ4M2Y4NTUwNjdhY2IiLCJwIjoiaiJ9).
Used to to be - set requires configuration if one of the input configurations lists are empty
Now - set requires configuration if **all** of the input configurations lists are empty.