### PR TITLE
support related objects

### DIFF
--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -61,7 +61,6 @@ type Control struct {
 	CreationTime          string       `json:"creationTime" bson:"creationTime"`
 	Description           string       `json:"description" bson:"description"`
 	Remediation           string       `json:"remediation" bson:"remediation"`
-	TypeTags              []string     `json:"typeTags" bson:"typeTags"`
 	Rules                 []PolicyRule `json:"rules" bson:"rules,omitempty"`
 	FrameworkNames        []string     `json:"frameworkNames,omitempty" bson:"frameworkNames,omitempty"`
 	BaseScore             float32      `json:"baseScore,omitempty" bson:"baseScore,omitempty"`

--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -77,6 +77,7 @@ type Framework struct {
 	armotypes.PortalBase `json:",inline" bson:"inline"`
 	CreationTime         string    `json:"creationTime" bson:"creationTime"`
 	Description          string    `json:"description" bson:"description"`
+	Type                 string    `json:"type" bson:"type"`
 	Controls             []Control `json:"controls" bson:"-"`
 	// for new list of  controls in POST/UPADTE requests
 	ControlsIDs *[]string                       `json:"controlsIDs,omitempty" bson:"controlsIDs,omitempty"`

--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -61,7 +61,7 @@ type Control struct {
 	CreationTime          string       `json:"creationTime" bson:"creationTime"`
 	Description           string       `json:"description" bson:"description"`
 	Remediation           string       `json:"remediation" bson:"remediation"`
-	ControlTypeTags       []string     `json:"controlTypeTags" bson:"controlTypeTags"`
+	TypeTags              []string     `json:"typeTags" bson:"typeTags"`
 	Rules                 []PolicyRule `json:"rules" bson:"rules,omitempty"`
 	FrameworkNames        []string     `json:"frameworkNames,omitempty" bson:"frameworkNames,omitempty"`
 	BaseScore             float32      `json:"baseScore,omitempty" bson:"baseScore,omitempty"`
@@ -78,7 +78,7 @@ type Framework struct {
 	armotypes.PortalBase `json:",inline" bson:"inline"`
 	CreationTime         string    `json:"creationTime" bson:"creationTime"`
 	Description          string    `json:"description" bson:"description"`
-	FrameworkTypeTags    []string  `json:"frameworkTypeTags" bson:"type"`
+	TypeTags             []string  `json:"typeTags" bson:"typeTags"`
 	Controls             []Control `json:"controls" bson:"-"`
 	// for new list of  controls in POST/UPADTE requests
 	ControlsIDs *[]string                       `json:"controlsIDs,omitempty" bson:"controlsIDs,omitempty"`

--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -61,6 +61,7 @@ type Control struct {
 	CreationTime          string       `json:"creationTime" bson:"creationTime"`
 	Description           string       `json:"description" bson:"description"`
 	Remediation           string       `json:"remediation" bson:"remediation"`
+	ControlTypeTags       []string     `json:"controlTypeTags" bson:"controlTypeTags"`
 	Rules                 []PolicyRule `json:"rules" bson:"rules,omitempty"`
 	FrameworkNames        []string     `json:"frameworkNames,omitempty" bson:"frameworkNames,omitempty"`
 	BaseScore             float32      `json:"baseScore,omitempty" bson:"baseScore,omitempty"`
@@ -77,7 +78,7 @@ type Framework struct {
 	armotypes.PortalBase `json:",inline" bson:"inline"`
 	CreationTime         string    `json:"creationTime" bson:"creationTime"`
 	Description          string    `json:"description" bson:"description"`
-	Type                 string    `json:"type" bson:"type"`
+	FrameworkTypeTags    []string  `json:"frameworkTypeTags" bson:"type"`
 	Controls             []Control `json:"controls" bson:"-"`
 	// for new list of  controls in POST/UPADTE requests
 	ControlsIDs *[]string                       `json:"controlsIDs,omitempty" bson:"controlsIDs,omitempty"`

--- a/reporthandling/datastructuresv1.go
+++ b/reporthandling/datastructuresv1.go
@@ -21,17 +21,26 @@ const (
 
 // RegoResponse the expected response of single run of rego policy
 type RuleResponse struct {
-	AlertMessage string                            `json:"alertMessage"`
-	FailedPaths  []string                          `json:"failedPaths"`          // path in yaml that led to failure of this resource
-	FixPaths     []armotypes.FixPath               `json:"fixPaths"`             // path in yaml to be added to fix this resource
-	FixCommand   string                            `json:"fixCommand,omitempty"` // command to fix this resource
-	RuleStatus   string                            `json:"ruleStatus"`
-	PackageName  string                            `json:"packagename"`
-	AlertScore   AlertScore                        `json:"alertScore"`
-	AlertObject  AlertObject                       `json:"alertObject"`
-	Context      []string                          `json:"context,omitempty"`  // TODO - Remove
-	Rulename     string                            `json:"rulename,omitempty"` // TODO - Remove
-	Exception    *armotypes.PostureExceptionPolicy `json:"exception,omitempty"`
+	AlertMessage   string                            `json:"alertMessage"`
+	FailedPaths    []string                          `json:"failedPaths"`          // path in yaml that led to failure of this resource
+	FixPaths       []armotypes.FixPath               `json:"fixPaths"`             // path in yaml to be added to fix this resource
+	FixCommand     string                            `json:"fixCommand,omitempty"` // command to fix this resource
+	RuleStatus     string                            `json:"ruleStatus"`
+	PackageName    string                            `json:"packagename"`
+	AlertScore     AlertScore                        `json:"alertScore"`
+	AlertObject    AlertObject                       `json:"alertObject"`
+	RelatedObjects []RelatedObject                   `json:"relatedObjects,omitempty"`
+	Context        []string                          `json:"context,omitempty"`  // TODO - Remove
+	Rulename       string                            `json:"rulename,omitempty"` // TODO - Remove
+	Exception      *armotypes.PostureExceptionPolicy `json:"exception,omitempty"`
+}
+
+// RelatedObjects - resource that is related to the failure of the main resource
+type RelatedObject struct {
+	Object      map[string]interface{} `json:"object"`
+	FailedPaths []string               `json:"failedPaths"`          // path in yaml that led to failure of this resource
+	FixPaths    []armotypes.FixPath    `json:"fixPaths"`             // path in yaml to be added to fix this resource
+	FixCommand  string                 `json:"fixCommand,omitempty"` // command to fix this resource
 }
 
 type AlertObject struct {

--- a/reporthandling/results/v1/resourcesresults/datastructures.go
+++ b/reporthandling/results/v1/resourcesresults/datastructures.go
@@ -32,4 +32,5 @@ type ResourceAssociatedRule struct {
 	SubStatus             apis.ScanningSubStatus             `json:"subStatus"`
 	Paths                 []armotypes.PosturePaths           `json:"paths,omitempty"`
 	Exception             []armotypes.PostureExceptionPolicy `json:"exception,omitempty"`
+	RelatedResourcesIDs   []string                           `json:"relatedResourcesIDs,omitempty"`
 }


### PR DESCRIPTION
This PR add the related object field in the rule response that can be used to indicate a resource that is part of the reason the main resource failed on a certain control.
It is also now possible to mark the assisted remediation on a related resource (fixPath/ failPath/ fixCommand).
This can be used in controls where the suggested fix need to be applied on a different resource than the main resource.
Note that the related resources is a list, therefore it is possible to suggest multiple fixes on different resources.