### PR TITLE
fix: exceptions not working always

### DIFF
--- a/reporthandling/results/v1/resourcesresults/exceptions.go
+++ b/reporthandling/results/v1/resourcesresults/exceptions.go
@@ -63,7 +63,7 @@ func (control *ResourceAssociatedControl) setExceptions(workload workloadinterfa
 		exceptionsPolicies = processor.ListRuleExceptions(exceptionsPolicies, "", control.GetName(), control.GetID(), "")
 		control.ResourceAssociatedRules[i].setExceptions(workload, exceptionsPolicies, clusterName, processor)
 		// Update rule status according to exceptions
-		control.ResourceAssociatedRules[i].SetStatus(control.Status.Status(), nil)
+		control.ResourceAssociatedRules[i].SetStatus(control.ResourceAssociatedRules[i].GetStatus(nil).Status(), nil)
 	}
 	// Update control status according to rules status
 	control.SetStatus(c)


### PR DESCRIPTION
## Overview

As mentioned in the issue, the exceptions would not work for some specific controls before, this has been fixed in this PR.

## Additional Information

Due to comparing the wrong value for checking if the current rule has passed or not the program would always update the state of the rules leading to a toggle situation, i.e., rules which failed initially would be changed to passed and the ones that had passed would be changed to failed, hence any control with a mix of passing and failing rules would always fail in the end even after applying the exception.

## How to Test

```bash
./kubescape scan control C-0211 resource.yaml --exceptions exception.json
```
Resource.yaml:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: myappname
  namespace: myappnamespace
spec:
  replicas: 1
  selector:
      matchLabels:
          app: myappname
  template:
      metadata:
          labels:
              app: myappname
      spec:
          containers:
            - image: azurecr.io/myappname:latest
              imagePullPolicy: Never
              name: myappname
```
Exception.json:
```json
[
    {
        "name": "exclude-allowed-hostPath-control",
        "policyType": "postureExceptionPolicy",
        "actions": [
            "alertOnly"
        ],
        "resources": [
            {
                "designatorType": "Attributes",
                "attributes": {
                    "kind": ".*"
                }
            }
        ],
        "posturePolicies": [
            {
                "controlID": "C-0211" 
            }
        ]
    }
]
```

## Examples/Screenshots

Before change:
![image](https://github.com/kubescape/opa-utils/assets/81813720/61811ac1-fd6a-4ffb-9b71-93a3a1e5972a)


After change:
![image](https://github.com/kubescape/opa-utils/assets/81813720/cdd8015a-bfa4-4c43-82e7-943bc3e8a2a2)


## Related issues/PRs:

Resolved #114 
Resolved https://github.com/kubescape/kubescape/issues/1125

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

