### PR TITLE
fix: set default control compliance score

### DIFF
--- a/reporthandling/results/v1/reportsummary/controlsummarymethods.go
+++ b/reporthandling/results/v1/reportsummary/controlsummarymethods.go
@@ -116,11 +116,11 @@ func (controlSummary *ControlSummary) GetScore() float32 {
 }
 
 func (controlSummary *ControlSummary) GetComplianceScore() float32 {
-	// if ComplianceScore field is set return it, else return -1
+	// if ComplianceScore field is set return it, else return 0
 	if controlSummary.ComplianceScore != nil {
 		return *controlSummary.ComplianceScore
 	}
-	return -1
+	return 0
 }
 
 // GetScoreFactor return control score


### PR DESCRIPTION
## Overview

As mentioned in the issue, the compliance score would be returned as `-1%` in case no resources were passed, it would be better to have this set to `0%` which make more sense from a percentage and score point of view.

## How to Test

Create an empty `resource.yaml` then:

```bash
./kubescape scan resource.yaml
```

## Examples/Screenshots

Before change:
![image](https://github.com/kubescape/opa-utils/assets/81813720/fe0cd807-ed07-42af-8dfe-840dbb897ed5)


After change:
![image](https://github.com/kubescape/opa-utils/assets/81813720/aaecce89-8e3e-440a-aa02-5f707f7b9da1)


## Related issues/PRs:

Resolved #116 
Resolved https://github.com/kubescape/kubescape/issues/1282

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes