### PR TITLE
fix: exception label matching

### DIFF
--- a/exceptions/comparator.go
+++ b/exceptions/comparator.go
@@ -72,13 +72,18 @@ func (c *comparator) compareLabels(workload workloadinterface.IMetadata, attribu
 	}
 
 	for key, val := range attributes {
-		for _, annotation := range workloadLabels {
-			if !workloadLabels.Has(key) {
-				return false
+		if !workloadLabels.Has(key) {
+			return false
+		}
+		found := false
+		for label, annotation := range workloadLabels {
+			if key == label && c.regexCompare(val, annotation) {
+				found = true
+				break
 			}
-			if !c.regexCompare(val, annotation) {
-				return false
-			}
+		}
+		if !found {
+			return false
 		}
 	}
 
@@ -97,13 +102,18 @@ func (c *comparator) compareAnnotations(workload workloadinterface.IMetadata, at
 	}
 
 	for key, val := range attributes {
-		for _, annotation := range workloadAnnotations {
-			if !workloadAnnotations.Has(key) {
-				return false
+		if !workloadAnnotations.Has(key) {
+			return false
+		}
+		found := false
+		for label, annotation := range workloadAnnotations {
+			if key == label && c.regexCompare(val, annotation) {
+				found = true
+				break
 			}
-			if !c.regexCompare(val, annotation) {
-				return false
-			}
+		}
+		if !found {
+			return false
 		}
 	}
 


### PR DESCRIPTION
## Overview

As mentioned in the issue, a label defined on the exception would only be matched if the target resource consists of a single label on it as well, hence forcing a one-to-one mapping of labels.

## Additional Context

The logic for matching labels had to be re-written because the implementation was mistakenly defined in such a way which would enforce this one-to-one mapping by mistake. Now the logic enforces that all the labels defined in the exception must all exist on the target resource for the exception to be applied, this creates an `and` logic that all must match, this coupled together with the ability to define multiple resource blocks in the exception file which act as an `or` logic will allow users to define any kind of conditional matching as now both `or` as well as `and` conditions are supported.


## How to Test

1. Create `resource.yaml`:
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: test-namespace
  labels:
    another-label: test
    exclude-from-kubescape: yes
```

2. Create `exception.json`:
```json
[
  {
    "name": "exclude-test",
    "policyType": "postureExceptionPolicy",
    "actions": ["alertOnly"],
    "resources": [
      {
        "designatorType": "Attributes",
        "attributes": {
          "exclude-from-kubescape": "yes"
        }
      }
    ],
    "posturePolicies": [
      {
        "controlID": "C-0054"
      }
    ]
  }
]
```

3. Run:
```bash
kubescape scan control C-0054 resource.yaml --exceptions exception.json
```

## Examples/Screenshots

Before change:
![image](https://github.com/kubescape/opa-utils/assets/81813720/19d9641d-8f84-4357-939f-7e0a87bec5b1)


After change:
![image](https://github.com/kubescape/opa-utils/assets/81813720/2d7814d3-3f59-4052-bb60-04367dd40aba)


## Related issues/PRs:

Resolved #122 
Resolved https://github.com/kubescape/kubescape/issues/1278

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes








