### PR TITLE
upgrade to armoapi-go v0.0.2xx

### DIFF
--- a/exceptions/designators_cache.go
+++ b/exceptions/designators_cache.go
@@ -3,7 +3,7 @@ package exceptions
 import (
 	"sync"
 
-	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
 	"github.com/kubescape/opa-utils/exceptions/internal/hashmap"
 )
 
@@ -14,11 +14,11 @@ type (
 	// a few slots for designators.
 	designatorCache struct {
 		mx       sync.RWMutex
-		innerMap map[portalDesignatorKey]armotypes.AttributesDesignators
+		innerMap map[portalDesignatorKey]identifiers.AttributesDesignators
 	}
 
 	portalDesignatorKey struct {
-		DesignatorType armotypes.DesignatorType
+		DesignatorType identifiers.DesignatorType
 		WLID           string
 		WildWLID       string
 		SID            string
@@ -37,11 +37,11 @@ func newDesignatorCache() *designatorCache {
 	const heuristicAllocDesignators = 1000 // this is a hint on the number of AttributeDesignators to hold, in order to minimize dynamic reallocations for this map
 
 	return &designatorCache{
-		innerMap: make(map[portalDesignatorKey]armotypes.AttributesDesignators, heuristicAllocDesignators),
+		innerMap: make(map[portalDesignatorKey]identifiers.AttributesDesignators, heuristicAllocDesignators),
 	}
 }
 
-func (c *designatorCache) Get(designator *armotypes.PortalDesignator) (armotypes.AttributesDesignators, bool) {
+func (c *designatorCache) Get(designator *identifiers.PortalDesignator) (identifiers.AttributesDesignators, bool) {
 	key := c.toDesignatorKey(designator)
 
 	c.mx.RLock()
@@ -52,7 +52,7 @@ func (c *designatorCache) Get(designator *armotypes.PortalDesignator) (armotypes
 	return val, ok
 }
 
-func (c *designatorCache) Set(designator *armotypes.PortalDesignator, value armotypes.AttributesDesignators) {
+func (c *designatorCache) Set(designator *identifiers.PortalDesignator, value identifiers.AttributesDesignators) {
 	key := c.toDesignatorKey(designator)
 
 	c.mx.Lock()
@@ -61,7 +61,7 @@ func (c *designatorCache) Set(designator *armotypes.PortalDesignator, value armo
 	c.innerMap[key] = value
 }
 
-func (c *designatorCache) toDesignatorKey(designator *armotypes.PortalDesignator) portalDesignatorKey {
+func (c *designatorCache) toDesignatorKey(designator *identifiers.PortalDesignator) portalDesignatorKey {
 	return portalDesignatorKey{
 		DesignatorType: designator.DesignatorType,
 		WLID:           designator.WLID,

--- a/exceptions/designators_cache_test.go
+++ b/exceptions/designators_cache_test.go
@@ -3,19 +3,19 @@ package exceptions
 import (
 	"testing"
 
-	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDesignatorsCache(t *testing.T) {
 	cache := &designatorCache{
-		innerMap: make(map[portalDesignatorKey]armotypes.AttributesDesignators, 1000),
+		innerMap: make(map[portalDesignatorKey]identifiers.AttributesDesignators, 1000),
 		// seed:     maphash.MakeSeed(), // for maphash version
 	}
 
 	t.Run("should retrieve cached designator", func(t *testing.T) {
-		designator := &armotypes.PortalDesignator{
-			DesignatorType: armotypes.DesignatorAttributes,
+		designator := &identifiers.PortalDesignator{
+			DesignatorType: identifiers.DesignatorAttributes,
 			WLID:           "x",
 			WildWLID:       "y",
 			SID:            "z",
@@ -38,8 +38,8 @@ func TestDesignatorsCache(t *testing.T) {
 	})
 
 	t.Run("should not collide with previously cached designator (WLID differs)", func(t *testing.T) {
-		designator := &armotypes.PortalDesignator{
-			DesignatorType: armotypes.DesignatorAttributes,
+		designator := &identifiers.PortalDesignator{
+			DesignatorType: identifiers.DesignatorAttributes,
 			WLID:           "x1",
 			WildWLID:       "y",
 			SID:            "z",
@@ -62,8 +62,8 @@ func TestDesignatorsCache(t *testing.T) {
 	})
 
 	t.Run("should not collide with previously cached designator (attributes differ)", func(t *testing.T) {
-		designator := &armotypes.PortalDesignator{
-			DesignatorType: armotypes.DesignatorAttributes,
+		designator := &identifiers.PortalDesignator{
+			DesignatorType: identifiers.DesignatorAttributes,
 			WLID:           "x",
 			WildWLID:       "y",
 			SID:            "z",
@@ -87,8 +87,8 @@ func TestDesignatorsCache(t *testing.T) {
 	})
 
 	t.Run("should support empty attributes", func(t *testing.T) {
-		designator := &armotypes.PortalDesignator{
-			DesignatorType: armotypes.DesignatorAttributes,
+		designator := &identifiers.PortalDesignator{
+			DesignatorType: identifiers.DesignatorAttributes,
 			WLID:           "x",
 			WildWLID:       "y",
 			SID:            "z",
@@ -109,11 +109,11 @@ func TestDesignatorsCache(t *testing.T) {
 
 func BenchmarkDesignatorsCache(b *testing.B) {
 	cache := &designatorCache{
-		innerMap: make(map[portalDesignatorKey]armotypes.AttributesDesignators, 1000),
+		innerMap: make(map[portalDesignatorKey]identifiers.AttributesDesignators, 1000),
 	}
 
-	designator := &armotypes.PortalDesignator{
-		DesignatorType: armotypes.DesignatorAttributes,
+	designator := &identifiers.PortalDesignator{
+		DesignatorType: identifiers.DesignatorAttributes,
 		WLID:           "x",
 		WildWLID:       "y",
 		SID:            "z",

--- a/exceptions/exceptionprocessor.go
+++ b/exceptions/exceptionprocessor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubescape/opa-utils/reporthandling"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
 )
 
 // Processor processes exceptions.
@@ -153,8 +154,8 @@ func (p *Processor) GetResourceExceptions(ruleExceptions []armotypes.PostureExce
 }
 
 // compareMetadata - compare namespace and kind
-func (p *Processor) hasException(clusterName string, designator *armotypes.PortalDesignator, workload workloadinterface.IMetadata) bool {
-	var attributes armotypes.AttributesDesignators
+func (p *Processor) hasException(clusterName string, designator *identifiers.PortalDesignator, workload workloadinterface.IMetadata) bool {
+	var attributes identifiers.AttributesDesignators
 	if attrs, ok := p.designatorCache.Get(designator); ok {
 		attributes = attrs
 	} else {

--- a/exceptions/exceptionprocessor_test.go
+++ b/exceptions/exceptionprocessor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
 )
 
 /* unused for now
@@ -23,12 +24,12 @@ func postureExceptionPolicyAlertOnlyMock() *armotypes.PostureExceptionPolicy {
 		},
 		PolicyType: "postureExceptionPolicy",
 		Actions:    []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
-		Resources: []armotypes.PortalDesignator{
+		Resources: []identifiers.PortalDesignator{
 			{
-				DesignatorType: armotypes.DesignatorAttributes,
+				DesignatorType: identifiers.DesignatorAttributes,
 				Attributes: map[string]string{
-					armotypes.AttributeNamespace: "default",
-					armotypes.AttributeCluster:   "unittest",
+					identifiers.AttributeNamespace: "default",
+					identifiers.AttributeCluster:   "unittest",
 				},
 			},
 		},
@@ -47,9 +48,9 @@ func postureLabelsRegexExceptionPolicyAlertOnlyMock() *armotypes.PostureExceptio
 		},
 		PolicyType: "postureExceptionPolicy",
 		Actions:    []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
-		Resources: []armotypes.PortalDesignator{
+		Resources: []identifiers.PortalDesignator{
 			{
-				DesignatorType: armotypes.DesignatorAttributes,
+				DesignatorType: identifiers.DesignatorAttributes,
 				Attributes: map[string]string{
 					"myLabelOrAnnotation": "static_test",
 				},
@@ -70,12 +71,12 @@ func postureResourceIDExceptionPolicyMock(resourceID string) *armotypes.PostureE
 		},
 		PolicyType: "postureExceptionPolicy",
 		Actions:    []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
-		Resources: []armotypes.PortalDesignator{
+		Resources: []identifiers.PortalDesignator{
 			{
-				DesignatorType: armotypes.DesignatorAttributes,
+				DesignatorType: identifiers.DesignatorAttributes,
 				Attributes: map[string]string{
-					armotypes.AttributeCluster:    "test",
-					armotypes.AttributeResourceID: resourceID,
+					identifiers.AttributeCluster:    "test",
+					identifiers.AttributeResourceID: resourceID,
 				},
 			},
 		},
@@ -94,9 +95,9 @@ func emptyPostureExceptionPolicyAlertOnlyMock() *armotypes.PostureExceptionPolic
 		},
 		PolicyType: "postureExceptionPolicy",
 		Actions:    []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
-		Resources: []armotypes.PortalDesignator{
+		Resources: []identifiers.PortalDesignator{
 			{
-				DesignatorType: armotypes.DesignatorAttributes,
+				DesignatorType: identifiers.DesignatorAttributes,
 				Attributes:     map[string]string{},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubescape/opa-utils
 go 1.19
 
 require (
-	github.com/armosec/armoapi-go v0.0.173
+	github.com/armosec/armoapi-go v0.0.207
 	github.com/armosec/utils-go v0.0.12
 	github.com/francoispqt/gojay v1.2.13
 	github.com/kubescape/k8s-interface v0.0.99
@@ -12,7 +12,7 @@ require (
 	github.com/open-policy-agent/opa v0.42.0
 	github.com/stretchr/testify v1.8.3
 	go.uber.org/zap v1.22.0
-	golang.org/x/exp v0.0.0-20230519143937-03e91628a987
+	golang.org/x/exp v0.0.0-20230711023510-fffb14384f22
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v0.25.3
@@ -35,6 +35,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/agnivade/levenshtein v1.0.1 // indirect
+	github.com/armosec/gojay v1.2.15 // indirect
 	github.com/armosec/utils-k8s-go v0.0.12 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.15.13 // indirect
@@ -101,7 +102,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b // indirect
 	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 // indirect
 	golang.org/x/oauth2 v0.0.0-20220630143837-2104d58473e0 // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,10 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/armosec/armoapi-go v0.0.173 h1:TwNxmTxx9ATJPZBlld/53s/WvSVUfoF4gxgHT6UbFng=
-github.com/armosec/armoapi-go v0.0.173/go.mod h1:xlW8dGq0vVzbuk+kDZqMQIkfU9P/iiiiDavoCIboqgI=
+github.com/armosec/armoapi-go v0.0.207 h1:xiayQ5w/odmMWuVXFhiqU6NQP5sXqZ6zwenc+Z+Z430=
+github.com/armosec/armoapi-go v0.0.207/go.mod h1:MSaFIxFu2ucjrY2RAzgasZbBlop+S7bNgRz5Q7iOmOc=
+github.com/armosec/gojay v1.2.15 h1:sSB2vnAvacUNkw9nzUYZKcPzhJOyk6/5LK2JCNdmoZY=
+github.com/armosec/gojay v1.2.15/go.mod h1:vzVAaay2TWJAngOpxu8aqLbye9jMgoKleuAOK+xsOts=
 github.com/armosec/utils-go v0.0.12 h1:NXkG/BhbSVAmTVXr0qqsK02CmxEiXuJyPmdTRcZ4jAo=
 github.com/armosec/utils-go v0.0.12/go.mod h1:F/K1mI/qcj7fNuJl7xktoCeHM83azOF0Zq6eC2WuPyU=
 github.com/armosec/utils-k8s-go v0.0.12 h1:u7kHSUp4PpvPP3hEaRXMbM0Vw23IyLhAzzE+2TW6Jkk=
@@ -1231,8 +1233,9 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b h1:huxqepDufQpLLIRXiVkTvnxrzJlpwmIWAObmcCcUFr0=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1243,8 +1246,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230519143937-03e91628a987 h1:3xJIFvzUFbu4ls0BTBYcgbCGhA63eAOEMxIHugyXJqA=
-golang.org/x/exp v0.0.0-20230519143937-03e91628a987/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+golang.org/x/exp v0.0.0-20230711023510-fffb14384f22 h1:FqrVOBQxQ8r/UwwXibI0KMolVhvFiGobSfdE33deHJM=
+golang.org/x/exp v0.0.0-20230711023510-fffb14384f22/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/reporthandling/results/v1/resourcesresults/exceptions_test.go
+++ b/reporthandling/results/v1/resourcesresults/exceptions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/armoapi-go/identifiers"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/exceptions"
 	"github.com/kubescape/opa-utils/reporthandling"
@@ -16,11 +17,11 @@ func mockExceptionDeploymentC0087() *armotypes.PostureExceptionPolicy {
 			Name: "DeploymentC0087",
 		},
 		Actions: []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
-		Resources: []armotypes.PortalDesignator{
+		Resources: []identifiers.PortalDesignator{
 			{
-				DesignatorType: armotypes.DesignatorAttributes,
+				DesignatorType: identifiers.DesignatorAttributes,
 				Attributes: map[string]string{
-					armotypes.AttributeKind: "Deployment",
+					identifiers.AttributeKind: "Deployment",
 				},
 			},
 		},
@@ -38,12 +39,12 @@ func mockExceptionUnitestDeploymentC0087() *armotypes.PostureExceptionPolicy {
 			Name: "unitestDeploymentC0087",
 		},
 		Actions: []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
-		Resources: []armotypes.PortalDesignator{
+		Resources: []identifiers.PortalDesignator{
 			{
-				DesignatorType: armotypes.DesignatorAttributes,
+				DesignatorType: identifiers.DesignatorAttributes,
 				Attributes: map[string]string{
-					armotypes.AttributeCluster: "unitest",
-					armotypes.AttributeKind:    "Deployment",
+					identifiers.AttributeCluster: "unitest",
+					identifiers.AttributeKind:    "Deployment",
 				},
 			},
 		},
@@ -61,11 +62,11 @@ func mockExceptionUnitestC0088() *armotypes.PostureExceptionPolicy {
 			Name: "unitestC0088",
 		},
 		Actions: []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
-		Resources: []armotypes.PortalDesignator{
+		Resources: []identifiers.PortalDesignator{
 			{
-				DesignatorType: armotypes.DesignatorAttributes,
+				DesignatorType: identifiers.DesignatorAttributes,
 				Attributes: map[string]string{
-					armotypes.AttributeCluster: "unitest",
+					identifiers.AttributeCluster: "unitest",
 				},
 			},
 		},
@@ -83,11 +84,11 @@ func mockExceptionDeploymentC0089() *armotypes.PostureExceptionPolicy {
 			Name: "Deployment0089",
 		},
 		Actions: []armotypes.PostureExceptionPolicyActions{armotypes.AlertOnly},
-		Resources: []armotypes.PortalDesignator{
+		Resources: []identifiers.PortalDesignator{
 			{
-				DesignatorType: armotypes.DesignatorAttributes,
+				DesignatorType: identifiers.DesignatorAttributes,
 				Attributes: map[string]string{
-					armotypes.AttributeKind: "Deployment",
+					identifiers.AttributeKind: "Deployment",
 				},
 			},
 		},


### PR DESCRIPTION
A bunch of structs from the armoapi-go module were moved from the `armotypes` package to the `identifiers` package.

This change upgrades the armoapi-go module from `v0.0.173` to `v0.0.207` and fixes the import errors as a result of doing this upgrade.