### PR TITLE
Field selectors support in RuleMatchObjectExtend and scan object support in httpserver API

### DIFF
--- a/httpserver/apis/v1/apis.go
+++ b/httpserver/apis/v1/apis.go
@@ -31,15 +31,3 @@ const (
 	// ReadyScanResponseType indicates that a server has successfully completed a request
 	ReadyScanResponseType ScanResponseType = "ready"
 )
-
-// A WorkloadScan contains the identifiers of a workload to be scanned
-type WorkloadScan struct {
-	// The ApiVersion of the workload
-	ApiVersion string `json:"apiVersion"`
-	// The kind of the workload
-	Kind string `json:"kind"`
-	// The name of the workload
-	Name string `json:"name"`
-	// The namespace of the workload
-	Namespace string `json:"namespace"`
-}

--- a/httpserver/apis/v1/apis.go
+++ b/httpserver/apis/v1/apis.go
@@ -31,3 +31,15 @@ const (
 	// ReadyScanResponseType indicates that a server has successfully completed a request
 	ReadyScanResponseType ScanResponseType = "ready"
 )
+
+// A WorkloadScan contains the identifiers of a workload to be scanned
+type WorkloadScan struct {
+	// The ApiVersion of the workload
+	ApiVersion string `json:"apiVersion"`
+	// The kind of the workload
+	Kind string `json:"kind"`
+	// The name of the workload
+	Name string `json:"name"`
+	// The namespace of the workload
+	Namespace string `json:"namespace"`
+}

--- a/httpserver/meta/v1/datastructure.go
+++ b/httpserver/meta/v1/datastructure.go
@@ -70,9 +70,12 @@ type PostScanRequest struct {
 	//
 	// Example: false
 	UseCachedArtifacts *bool `json:"useCachedArtifacts,omitempty"`
-	// UseExceptions      string      // Load file with exceptions configuration
-	// ControlsInputs     string      // Load file with inputs for controls
-	// VerboseMode        bool        // Display all of the input resources and not only failed resources
+	// Scan a specific workload
+	//
+	// Same as `kubescape scan workload <workloadIdentifier>`
+	//
+	// Example: {"apiVersion": "apps/v1", "kind": "Deployment", "name": "nginx", "namespace": "my-namespace"}
+	Workload *v1.WorkloadScan `json:"workload,omitempty"`
 }
 
 // A Scan Response object

--- a/httpserver/meta/v1/datastructure.go
+++ b/httpserver/meta/v1/datastructure.go
@@ -1,6 +1,9 @@
 package v1
 
-import v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+import (
+	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	"github.com/kubescape/opa-utils/objectsenvelopes"
+)
 
 // A request to trigger a Kubescape scan
 type PostScanRequest struct {
@@ -70,12 +73,10 @@ type PostScanRequest struct {
 	//
 	// Example: false
 	UseCachedArtifacts *bool `json:"useCachedArtifacts,omitempty"`
-	// Scan a specific workload
+	// Scan a specific K8S object
 	//
-	// Same as `kubescape scan workload <workloadIdentifier>`
-	//
-	// Example: {"apiVersion": "apps/v1", "kind": "Deployment", "name": "nginx", "namespace": "my-namespace"}
-	Workload *v1.WorkloadScan `json:"workload,omitempty"`
+	// Example: {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": { "name": "nginx", "namespace": "my-namespace"} }
+	ScanObject *objectsenvelopes.ScanObject `json:"scanObject,omitempty"`
 }
 
 // A Scan Response object

--- a/objectsenvelopes/scanobject.go
+++ b/objectsenvelopes/scanobject.go
@@ -113,7 +113,7 @@ func (scanObject *ScanObject) GetObject() map[string]interface{} {
 }
 
 func (scanObject *ScanObject) GetID() string {
-	return fmt.Sprintf("%s/%s/%s", k8sinterface.JoinGroupVersion(k8sinterface.SplitApiVersion(scanObject.GetApiVersion())), scanObject.GetKind(), scanObject.GetName())
+	return fmt.Sprintf("%s/%s/%s/%s", k8sinterface.JoinGroupVersion(k8sinterface.SplitApiVersion(scanObject.GetApiVersion())), scanObject.GetNamespace(), scanObject.GetKind(), scanObject.GetName())
 }
 
 func (scanObject *ScanObject) GetObjectType() workloadinterface.ObjectType {

--- a/objectsenvelopes/scanobject.go
+++ b/objectsenvelopes/scanobject.go
@@ -1,0 +1,156 @@
+package objectsenvelopes
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+)
+
+var _ workloadinterface.IMetadata = (*ScanObject)(nil)
+
+type ScanObjectMetadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// A ScanObject represents a K8S object to be scanned
+type ScanObject struct {
+	ApiVersion string             `json:"apiVersion"`
+	Kind       string             `json:"kind"`
+	Metadata   ScanObjectMetadata `json:"metadata"`
+}
+
+func IsTypeScanObject(object map[string]interface{}) bool {
+	if object == nil {
+		return false
+	}
+
+	if _, ok := object["apiVersion"]; !ok {
+		return false
+	}
+	if _, ok := object["kind"]; !ok {
+		return false
+	}
+
+	if _, ok := object["metadata"]; !ok {
+		return false
+	}
+
+	metadata, ok := object["metadata"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	if _, ok = metadata["name"]; !ok {
+		return false
+	}
+
+	return true
+}
+
+// NewScanObject construct a ScanObject from map[string]interface{}. If the map does not match the object, will return nil
+func NewScanObject(object map[string]interface{}) *ScanObject {
+	if !IsTypeScanObject(object) {
+		return nil
+	}
+
+	scanObject := &ScanObject{}
+	if b := workloadinterface.MapToBytes(object); b != nil {
+		if err := json.Unmarshal(b, scanObject); err != nil {
+			return nil
+		}
+	} else {
+		return nil
+	}
+	return scanObject
+}
+
+func (scanObject *ScanObject) GetNamespace() string {
+	return scanObject.Metadata.GetNamespace()
+}
+
+func (scanObjectMetadata *ScanObjectMetadata) GetName() string {
+	return scanObjectMetadata.Name
+}
+
+func (scanObjectMetadata *ScanObjectMetadata) GetNamespace() string {
+	return scanObjectMetadata.Namespace
+}
+
+func (scanObjectMetadata *ScanObjectMetadata) SetName(name string) {
+	scanObjectMetadata.Name = name
+}
+
+func (scanObjectMetadata *ScanObjectMetadata) SetNamespace(namespace string) {
+	scanObjectMetadata.Namespace = namespace
+}
+
+func (scanObject *ScanObject) GetName() string {
+	return scanObject.Metadata.GetName()
+}
+
+func (scanObject *ScanObject) GetKind() string {
+	return scanObject.Kind
+}
+
+func (scanObject *ScanObject) GetApiVersion() string {
+	return scanObject.ApiVersion
+}
+
+func (scanObject *ScanObject) GetWorkload() map[string]interface{} {
+	return scanObject.GetObject()
+}
+
+func (scanObject *ScanObject) GetObject() map[string]interface{} {
+	m := map[string]interface{}{}
+	b, err := json.Marshal(*scanObject)
+	if err != nil {
+		return m
+	}
+	return workloadinterface.BytesToMap(b)
+}
+
+func (scanObject *ScanObject) GetID() string {
+	return fmt.Sprintf("%s/%s/%s", k8sinterface.JoinGroupVersion(k8sinterface.SplitApiVersion(scanObject.GetApiVersion())), scanObject.GetKind(), scanObject.GetName())
+}
+
+func (scanObject *ScanObject) GetObjectType() workloadinterface.ObjectType {
+	return GetObjectType(scanObject.GetObject())
+}
+
+func (scanObject *ScanObject) SetNamespace(namespace string) {
+	scanObject.Metadata.SetNamespace(namespace)
+}
+
+func (scanObject *ScanObject) SetName(name string) {
+	scanObject.Metadata.SetName(name)
+}
+
+func (scanObject *ScanObject) SetKind(kind string) {
+	scanObject.Kind = kind
+}
+
+func (scanObject *ScanObject) SetWorkload(object map[string]interface{}) {
+	scanObject.SetObject(object)
+}
+
+func (scanObject *ScanObject) SetObject(object map[string]interface{}) {
+	if !IsTypeScanObject(object) {
+		return
+	}
+	if b := workloadinterface.MapToBytes(object); len(b) > 0 {
+		obj := &ScanObject{}
+		if err := json.Unmarshal(b, obj); err == nil {
+			scanObject.SetApiVersion(obj.GetApiVersion())
+			scanObject.SetKind(obj.GetKind())
+			scanObject.SetName(obj.GetName())
+			scanObject.SetNamespace(obj.GetNamespace())
+		}
+	}
+}
+
+func (scanObject *ScanObject) SetApiVersion(apiVersion string) {
+	scanObject.ApiVersion = apiVersion
+}

--- a/objectsenvelopes/scanobject_test.go
+++ b/objectsenvelopes/scanobject_test.go
@@ -17,7 +17,8 @@ func TestNewScanObject(t *testing.T) {
 		"kind":       "Pod",
 		"apiVersion": "v1",
 		"metadata": map[string]interface{}{
-			"name": "test-pod",
+			"name":      "test-pod",
+			"namespace": "test-namespace",
 		},
 	}
 	scanObj := NewScanObject(object)
@@ -25,29 +26,109 @@ func TestNewScanObject(t *testing.T) {
 	assert.Equal(t, "Pod", scanObj.GetKind())
 	assert.Equal(t, "v1", scanObj.GetApiVersion())
 	assert.Equal(t, "test-pod", scanObj.GetName())
-	assert.Equal(t, "", scanObj.GetNamespace())
-	scanObj.SetNamespace("test-namespace")
 	assert.Equal(t, "test-namespace", scanObj.GetNamespace())
 	assert.Equal(t, workloadinterface.TypeWorkloadObject, scanObj.GetObjectType())
-
-	// test json marshal
-	jsonEnc, err := json.Marshal(scanObj)
-	expectedJsonStr := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-pod","namespace":"test-namespace"}}`
-	assert.NoError(t, err)
-	assert.Equal(t, expectedJsonStr, string(jsonEnc))
-
-	// test json unmarshal
-	var scanObj2 ScanObject
-	jsonStr := `{"apiVersion":"v1","kind":"Node","metadata":{"name":"node-1"},"field":"value"}`
-	err = json.Unmarshal([]byte(jsonStr), &scanObj2)
-	assert.NoError(t, err)
-	assert.Equal(t, "Node", scanObj2.GetKind())
-	assert.Equal(t, "node-1", scanObj2.GetName())
-	assert.Equal(t, "", scanObj2.GetNamespace())
 
 	// Test unsupported input
 	unsupportedObject := map[string]interface{}{
 		"unknown": "unknown",
 	}
 	assert.Nil(t, NewScanObject(unsupportedObject))
+}
+
+func TestScanObjectMarshal(t *testing.T) {
+	scanObj := ScanObject{
+		Kind:       "Pod",
+		ApiVersion: "v1",
+		Metadata: ScanObjectMetadata{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// test json marshal
+	jsonEnc, err := json.Marshal(scanObj)
+	expectedJsonStr := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-pod","namespace":"test-namespace"}}`
+	assert.NoError(t, err)
+	assert.Equal(t, expectedJsonStr, string(jsonEnc))
+}
+
+func TestScanObjectUnmarshal(t *testing.T) {
+	var scanObj ScanObject
+	jsonStr := `{"apiVersion":"v1","kind":"Node","metadata":{"name":"node-1"},"field":"value"}`
+	err := json.Unmarshal([]byte(jsonStr), &scanObj)
+	assert.NoError(t, err)
+	assert.Equal(t, "Node", scanObj.GetKind())
+	assert.Equal(t, "node-1", scanObj.GetName())
+	assert.Equal(t, "", scanObj.GetNamespace())
+}
+
+func TestScanObjectSetters(t *testing.T) {
+	scanObj := ScanObject{}
+
+	scanObj.SetKind("Node")
+	assert.Equal(t, "Node", scanObj.Kind)
+
+	scanObj.SetApiVersion("v2")
+	assert.Equal(t, "v2", scanObj.ApiVersion)
+
+	scanObj.SetName("node-1")
+	assert.Equal(t, "node-1", scanObj.Metadata.Name)
+
+	scanObj.SetNamespace("namespace")
+	assert.Equal(t, "namespace", scanObj.Metadata.Namespace)
+
+	// test invalid objects - should remain unchanged
+	scanObj.SetObject(map[string]interface{}{
+		"invalid": "object",
+	})
+	scanObj.SetObject(map[string]interface{}{
+		"apiVersion": "v3",
+	})
+	scanObj.SetObject(map[string]interface{}{
+		"apiVersion": "v3",
+		"kind":       "Secret",
+	})
+	scanObj.SetObject(map[string]interface{}{
+		"apiVersion": "v3",
+		"kind":       "Secret",
+		"metadata":   "invalid_type",
+	})
+	scanObj.SetObject(map[string]interface{}{
+		"apiVersion": "v3",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"namespace": "ns-1",
+		},
+	})
+	assert.Equal(t, "Node", scanObj.Kind)
+
+	scanObj.SetObject(map[string]interface{}{
+		"kind":       "Pod",
+		"apiVersion": "v1",
+		"metadata": map[string]interface{}{
+			"name": "test-pod",
+		},
+	})
+	assert.Equal(t, "Pod", scanObj.Kind)
+	assert.Equal(t, "v1", scanObj.ApiVersion)
+	assert.Equal(t, "test-pod", scanObj.Metadata.Name)
+}
+
+func TestScanObjectGetters(t *testing.T) {
+	scanObj := ScanObject{
+		Kind:       "Pod",
+		ApiVersion: "v1",
+		Metadata: ScanObjectMetadata{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
+	}
+
+	assert.Equal(t, "Pod", scanObj.GetKind())
+	assert.Equal(t, "v1", scanObj.GetApiVersion())
+	assert.Equal(t, "test-pod", scanObj.GetName())
+	assert.Equal(t, "test-namespace", scanObj.GetNamespace())
+	assert.Equal(t, workloadinterface.TypeWorkloadObject, scanObj.GetObjectType())
+	assert.Equal(t, "/v1/test-namespace/Pod/test-pod", scanObj.GetID())
 }

--- a/objectsenvelopes/scanobject_test.go
+++ b/objectsenvelopes/scanobject_test.go
@@ -1,0 +1,53 @@
+package objectsenvelopes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewScanObject(t *testing.T) {
+	// Test nil input
+	assert.Nil(t, NewScanObject(nil))
+
+	// Test valid input
+	object := map[string]interface{}{
+		"kind":       "Pod",
+		"apiVersion": "v1",
+		"metadata": map[string]interface{}{
+			"name": "test-pod",
+		},
+	}
+	scanObj := NewScanObject(object)
+	assert.NotNil(t, scanObj)
+	assert.Equal(t, "Pod", scanObj.GetKind())
+	assert.Equal(t, "v1", scanObj.GetApiVersion())
+	assert.Equal(t, "test-pod", scanObj.GetName())
+	assert.Equal(t, "", scanObj.GetNamespace())
+	scanObj.SetNamespace("test-namespace")
+	assert.Equal(t, "test-namespace", scanObj.GetNamespace())
+	assert.Equal(t, workloadinterface.TypeWorkloadObject, scanObj.GetObjectType())
+
+	// test json marshal
+	jsonEnc, err := json.Marshal(scanObj)
+	expectedJsonStr := `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"test-pod","namespace":"test-namespace"}}`
+	assert.NoError(t, err)
+	assert.Equal(t, expectedJsonStr, string(jsonEnc))
+
+	// test json unmarshal
+	var scanObj2 ScanObject
+	jsonStr := `{"apiVersion":"v1","kind":"Node","metadata":{"name":"node-1"},"field":"value"}`
+	err = json.Unmarshal([]byte(jsonStr), &scanObj2)
+	assert.NoError(t, err)
+	assert.Equal(t, "Node", scanObj2.GetKind())
+	assert.Equal(t, "node-1", scanObj2.GetName())
+	assert.Equal(t, "", scanObj2.GetNamespace())
+
+	// Test unsupported input
+	unsupportedObject := map[string]interface{}{
+		"unknown": "unknown",
+	}
+	assert.Nil(t, NewScanObject(unsupportedObject))
+}

--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -18,9 +18,10 @@ const (
 
 // RuleMatchObjects defines which objects this rule applied on
 type RuleMatchObjects struct {
-	APIGroups   []string `json:"apiGroups" bson:"apiGroups"`     // apps
-	APIVersions []string `json:"apiVersions" bson:"apiVersions"` // v1/ v1beta1 / *
-	Resources   []string `json:"resources" bson:"resources"`     // dep.., pods,
+	APIGroups     []string `json:"apiGroups" bson:"apiGroups"`         // apps
+	APIVersions   []string `json:"apiVersions" bson:"apiVersions"`     // v1/ v1beta1 / *
+	Resources     []string `json:"resources" bson:"resources"`         // dep.., pods,
+	FieldSelector []string `json:"fieldSelector" bson:"fieldSelector"` // fields selector for example metadata.name==nginx,metadata.namespace==ns1
 }
 
 type RuleDependency struct {

--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -18,10 +18,10 @@ const (
 
 // RuleMatchObjects defines which objects this rule applied on
 type RuleMatchObjects struct {
-	APIGroups     []string `json:"apiGroups" bson:"apiGroups"`         // apps
-	APIVersions   []string `json:"apiVersions" bson:"apiVersions"`     // v1/ v1beta1 / *
-	Resources     []string `json:"resources" bson:"resources"`         // dep.., pods,
-	FieldSelector []string `json:"fieldSelector" bson:"fieldSelector"` // fields selector for example metadata.name==nginx,metadata.namespace==ns1
+	APIGroups     []string `json:"apiGroups" bson:"apiGroups"`                             // apps
+	APIVersions   []string `json:"apiVersions" bson:"apiVersions"`                         // v1/ v1beta1 / *
+	Resources     []string `json:"resources" bson:"resources"`                             // dep.., pods,
+	FieldSelector []string `json:"fieldSelector,omitempty" bson:"fieldSelector,omitempty"` // fields selector for example metadata.name==nginx,metadata.namespace==ns1
 }
 
 type RuleDependency struct {


### PR DESCRIPTION
### Overview

- Field selectors support in `RuleMatchObject` 
- Extend PostScanRequest object of Kubescape to support a single resource scan (https://github.com/kubescape/kubescape/pull/1300/files)