### PR TITLE
Support scanning a deleted resource 

### DIFF
--- a/httpserver/meta/v1/datastructure.go
+++ b/httpserver/meta/v1/datastructure.go
@@ -77,6 +77,10 @@ type PostScanRequest struct {
 	//
 	// Example: {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": { "name": "nginx", "namespace": "my-namespace"} }
 	ScanObject *objectsenvelopes.ScanObject `json:"scanObject,omitempty"`
+	// Specifies whether the ScanObject is a deleted K8S resource so that the scan will be performed without fetching the resource
+	//
+	// Example: true
+	IsDeletedScanObject *bool `json:"isDeletedScanObject,omitempty"`
 }
 
 // A Scan Response object


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces an enhancement to the scanning process of Kubernetes resources. It adds a new field 'DeletedScanObject' in the 'PostScanRequest' struct. This field indicates whether the ScanObject is a deleted Kubernetes resource, allowing the scan to be performed without fetching the resource.

___
## PR Main Files Walkthrough:
`httpserver/meta/v1/datastructure.go`: Added a new field 'DeletedScanObject' in the 'PostScanRequest' struct. This field is a boolean that indicates whether the ScanObject is a deleted Kubernetes resource.
