### PR TITLE
add delete path and review path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubescape/opa-utils
 go 1.20
 
 require (
-	github.com/armosec/armoapi-go v0.0.220
+	github.com/armosec/armoapi-go v0.0.256-0.20230928083624-dbd919873fcb
 	github.com/armosec/utils-go v0.0.20
 	github.com/francoispqt/gojay v1.2.13
 	github.com/kubescape/k8s-interface v0.0.135-0.20230730135750-e6e709507847

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubescape/opa-utils
 go 1.20
 
 require (
-	github.com/armosec/armoapi-go v0.0.256-0.20230928083624-dbd919873fcb
+	github.com/armosec/armoapi-go v0.0.256-0.20230928144732-6dc515782a26
 	github.com/armosec/utils-go v0.0.20
 	github.com/francoispqt/gojay v1.2.13
 	github.com/kubescape/k8s-interface v0.0.135-0.20230730135750-e6e709507847

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubescape/opa-utils
 go 1.20
 
 require (
-	github.com/armosec/armoapi-go v0.0.256-0.20230928144732-6dc515782a26
+	github.com/armosec/armoapi-go v0.0.256
 	github.com/armosec/utils-go v0.0.20
 	github.com/francoispqt/gojay v1.2.13
 	github.com/kubescape/k8s-interface v0.0.135-0.20230730135750-e6e709507847

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
-github.com/armosec/armoapi-go v0.0.220 h1:gfg2UmcFgcyStjp5ZXfwE8yb0H43eaRX9H/KkqFIv6w=
-github.com/armosec/armoapi-go v0.0.220/go.mod h1:Y1ZcqPUTQ+F8JiQzErrToK5ULrPvClxZoshHmV9PIlU=
+github.com/armosec/armoapi-go v0.0.256-0.20230928083624-dbd919873fcb h1:S3/C7qeIAHZAu/yXoM1Kz5V046ZwdmbnbeoBB693Pp0=
+github.com/armosec/armoapi-go v0.0.256-0.20230928083624-dbd919873fcb/go.mod h1:CJT5iH5VF30zjdQYXaQhsAm8IEHtM1T87HcFVXeLX54=
 github.com/armosec/gojay v1.2.15 h1:sSB2vnAvacUNkw9nzUYZKcPzhJOyk6/5LK2JCNdmoZY=
 github.com/armosec/gojay v1.2.15/go.mod h1:vzVAaay2TWJAngOpxu8aqLbye9jMgoKleuAOK+xsOts=
 github.com/armosec/utils-go v0.0.20 h1:bvr+TMumEYdMsGFGSsaQysST7K02nNROFvuajNuKPlw=

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
-github.com/armosec/armoapi-go v0.0.256-0.20230928083624-dbd919873fcb h1:S3/C7qeIAHZAu/yXoM1Kz5V046ZwdmbnbeoBB693Pp0=
-github.com/armosec/armoapi-go v0.0.256-0.20230928083624-dbd919873fcb/go.mod h1:CJT5iH5VF30zjdQYXaQhsAm8IEHtM1T87HcFVXeLX54=
+github.com/armosec/armoapi-go v0.0.256-0.20230928144732-6dc515782a26 h1:oIjALDFe2CxmPEJ7Py5PZfcLFHBnPeGCwIi9LOOH7Cg=
+github.com/armosec/armoapi-go v0.0.256-0.20230928144732-6dc515782a26/go.mod h1:CJT5iH5VF30zjdQYXaQhsAm8IEHtM1T87HcFVXeLX54=
 github.com/armosec/gojay v1.2.15 h1:sSB2vnAvacUNkw9nzUYZKcPzhJOyk6/5LK2JCNdmoZY=
 github.com/armosec/gojay v1.2.15/go.mod h1:vzVAaay2TWJAngOpxu8aqLbye9jMgoKleuAOK+xsOts=
 github.com/armosec/utils-go v0.0.20 h1:bvr+TMumEYdMsGFGSsaQysST7K02nNROFvuajNuKPlw=

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
-github.com/armosec/armoapi-go v0.0.256-0.20230928144732-6dc515782a26 h1:oIjALDFe2CxmPEJ7Py5PZfcLFHBnPeGCwIi9LOOH7Cg=
-github.com/armosec/armoapi-go v0.0.256-0.20230928144732-6dc515782a26/go.mod h1:CJT5iH5VF30zjdQYXaQhsAm8IEHtM1T87HcFVXeLX54=
+github.com/armosec/armoapi-go v0.0.256 h1:eV8WWQ1r+2D0KHhLA6ux6lx67+uqkYe/uVHrOUFqz5c=
+github.com/armosec/armoapi-go v0.0.256/go.mod h1:CJT5iH5VF30zjdQYXaQhsAm8IEHtM1T87HcFVXeLX54=
 github.com/armosec/gojay v1.2.15 h1:sSB2vnAvacUNkw9nzUYZKcPzhJOyk6/5LK2JCNdmoZY=
 github.com/armosec/gojay v1.2.15/go.mod h1:vzVAaay2TWJAngOpxu8aqLbye9jMgoKleuAOK+xsOts=
 github.com/armosec/utils-go v0.0.20 h1:bvr+TMumEYdMsGFGSsaQysST7K02nNROFvuajNuKPlw=

--- a/reporthandling/datastructuresv1.go
+++ b/reporthandling/datastructuresv1.go
@@ -40,7 +40,8 @@ type RelatedObject struct {
 }
 
 type AssistedRemediation struct {
-	FailedPaths []string            `json:"failedPaths"`          // path in yaml that led to failure of this resource
+	FailedPaths []string            `json:"failedPaths"`          // path in yaml that led to failure of this resource TODO - deprecate
+	ReviewPaths []string            `json:"reviewPaths"`          // path in yaml that led to failure of this resource
 	DeletePaths []string            `json:"deletePaths"`          // path in yaml to be deleted to remediate this resource
 	FixPaths    []armotypes.FixPath `json:"fixPaths"`             // path in yaml to be added to fix this resource
 	FixCommand  string              `json:"fixCommand,omitempty"` // command to fix this resource

--- a/reporthandling/datastructuresv1.go
+++ b/reporthandling/datastructuresv1.go
@@ -21,28 +21,30 @@ const (
 
 // RegoResponse the expected response of single run of rego policy
 type RuleResponse struct {
-	AlertMessage   string                            `json:"alertMessage"`
-	FailedPaths    []string                          `json:"failedPaths"`          // path in yaml that led to failure of this resource
-	FixPaths       []armotypes.FixPath               `json:"fixPaths"`             // path in yaml to be added to fix this resource
-	FixCommand     string                            `json:"fixCommand,omitempty"` // command to fix this resource
-	RuleStatus     string                            `json:"ruleStatus"`
-	PackageName    string                            `json:"packagename"`
-	AlertScore     AlertScore                        `json:"alertScore"`
-	AlertObject    AlertObject                       `json:"alertObject"`
-	RelatedObjects []RelatedObject                   `json:"relatedObjects,omitempty"`
-	Context        []string                          `json:"context,omitempty"`  // TODO - Remove
-	Rulename       string                            `json:"rulename,omitempty"` // TODO - Remove
-	Exception      *armotypes.PostureExceptionPolicy `json:"exception,omitempty"`
+	AlertMessage        string `json:"alertMessage"`
+	AssistedRemediation `json:",inline"`
+	RuleStatus          string                            `json:"ruleStatus"`
+	PackageName         string                            `json:"packagename"`
+	AlertScore          AlertScore                        `json:"alertScore"`
+	AlertObject         AlertObject                       `json:"alertObject"`
+	RelatedObjects      []RelatedObject                   `json:"relatedObjects,omitempty"`
+	Context             []string                          `json:"context,omitempty"`  // TODO - Remove
+	Rulename            string                            `json:"rulename,omitempty"` // TODO - Remove
+	Exception           *armotypes.PostureExceptionPolicy `json:"exception,omitempty"`
 }
 
 // RelatedObjects - resource that is related to the failure of the main resource
 type RelatedObject struct {
-	Object      map[string]interface{} `json:"object"`
-	FailedPaths []string               `json:"failedPaths"`          // path in yaml that led to failure of this resource
-	FixPaths    []armotypes.FixPath    `json:"fixPaths"`             // path in yaml to be added to fix this resource
-	FixCommand  string                 `json:"fixCommand,omitempty"` // command to fix this resource
+	Object              map[string]interface{} `json:"object"`
+	AssistedRemediation `json:",inline"`
 }
 
+type AssistedRemediation struct {
+	FailedPaths []string            `json:"failedPaths"`          // path in yaml that led to failure of this resource
+	DeletePaths []string            `json:"deletePaths"`          // path in yaml to be deleted to remediate this resource
+	FixPaths    []armotypes.FixPath `json:"fixPaths"`             // path in yaml to be added to fix this resource
+	FixCommand  string              `json:"fixCommand,omitempty"` // command to fix this resource
+}
 type AlertObject struct {
 	K8SApiObjects   []map[string]interface{} `json:"k8sApiObjects,omitempty"`
 	ExternalObjects map[string]interface{}   `json:"externalObjects,omitempty"`


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the addition of 'deletePaths' and 'reviewPaths' to the AssistedRemediation struct. These paths will be used to provide more detailed remediation suggestions. The PR also includes an update to the 'armoapi-go' version.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`reporthandling/datastructuresv1.go`: Introduced 'deletePaths' and 'reviewPaths' in the AssistedRemediation struct. Refactored the RuleResponse and RelatedObject structs to include AssistedRemediation inline.
`go.mod`: Updated the version of 'armoapi-go' from v0.0.220 to v0.0.256.
`go.sum`: Updated the checksums for 'armoapi-go' to reflect the new version.
</details>
