### PR TITLE
Adding access keys to request object

### DIFF
--- a/httpserver/meta/v1/datastructure.go
+++ b/httpserver/meta/v1/datastructure.go
@@ -23,6 +23,14 @@ type PostScanRequest struct {
 	// swagger:strfmt uuid4
 	//
 	Account string `json:"account,omitempty"`
+	// A Kubescape access key to use for scanning.
+	//
+	// Same as `kubescape scan --access-key`.
+	//
+	// Example: d13791eb-19b1-4222-867b-9a7c1799cfac
+	// swagger:strfmt uuid4
+	//
+	AccessKey string `json:"accessKey,omitempty"`
 	// Threshold for a failing score.
 	//
 	// Scores higher than the provided value will be considered failing.


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces an enhancement to the PostScanRequest structure in the 'httpserver/meta/v1/datastructure.go' file. The following changes have been made:
- An 'AccessKey' field has been added to the PostScanRequest structure. This field is used to store the Kubescape access key for scanning.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`httpserver/meta/v1/datastructure.go`: Added an 'AccessKey' field to the PostScanRequest structure. This field is used to store the Kubescape access key for scanning.
</details>
