### PR TITLE
Update datastructuresmethods_test.go

### DIFF
--- a/reporthandling/datastructuresmethods_test.go
+++ b/reporthandling/datastructuresmethods_test.go
@@ -115,20 +115,20 @@ func TestListResourcesIDs(t *testing.T) {
 }
 
 func TestControl_GetAttackTrackCategories(t *testing.T) {
-	validControlJson := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"],"attackTracks":[{"attackTrack": "container","categories": ["Execution","Initial access"]}]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	validControlJson := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"attackTracks":[{"attackTrack": "container","categories": ["Execution","Initial access"]}]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var validControl Control
 	err := json.Unmarshal([]byte(validControlJson), &validControl)
 	assert.NoError(t, err, err)
 	assert.Equal(t, []string{"Execution", "Initial access"}, validControl.GetAttackTrackCategories("container"))
 	assert.Equal(t, []string{}, validControl.GetAttackTrackCategories("test"))
 
-	invalidControlJson1 := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"],"attackTracks":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	invalidControlJson1 := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"attackTracks":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var invalidControl1 Control
 	err = json.Unmarshal([]byte(invalidControlJson1), &invalidControl1)
 	assert.NoError(t, err, err)
 	assert.Equal(t, []string{}, invalidControl1.GetAttackTrackCategories("container"))
 
-	invalidControlJson2 := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"],"attack":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	invalidControlJson2 := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"attack":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var invalidControl2 Control
 	err = json.Unmarshal([]byte(invalidControlJson2), &invalidControl2)
 	assert.NoError(t, err, err)
@@ -136,7 +136,7 @@ func TestControl_GetAttackTrackCategories(t *testing.T) {
 }
 
 func TestControl_GetAllAttackTracks(t *testing.T) {
-	validControlJson := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"],"attackTracks":[{"attackTrack": "container","categories": ["Execution","Initial access"]},{"attackTrack": "network","categories": ["Eavesdropping","Spoofing"]}]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	validControlJson := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"attackTracks":[{"attackTrack": "container","categories": ["Execution","Initial access"]},{"attackTrack": "network","categories": ["Eavesdropping","Spoofing"]}]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var validControl Control
 	err := json.Unmarshal([]byte(validControlJson), &validControl)
 	assert.NoError(t, err)
@@ -152,27 +152,27 @@ func TestControl_GetAllAttackTracks(t *testing.T) {
 	}
 	assert.ElementsMatch(t, expectedTracks, validControl.GetAllAttackTrackCategories())
 
-	invalidControlJson1 := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"],"attackTracks":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	invalidControlJson1 := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"attackTracks":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var invalidControl1 Control
 	err = json.Unmarshal([]byte(invalidControlJson1), &invalidControl1)
 	assert.NoError(t, err)
 	assert.Nil(t, invalidControl1.GetAllAttackTrackCategories())
 
-	invalidControlJson2 := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"],"attack":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	invalidControlJson2 := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"attack":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var invalidControl2 Control
 	err = json.Unmarshal([]byte(invalidControlJson2), &invalidControl2)
 	assert.NoError(t, err)
 	assert.Nil(t, invalidControl2.GetAllAttackTrackCategories())
 
 	// Case: control that has no "attackTracks" field
-	missingAttackTrackJson := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	missingAttackTrackJson := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var missingAttackTrackControl Control
 	err = json.Unmarshal([]byte(missingAttackTrackJson), &missingAttackTrackControl)
 	assert.NoError(t, err)
 	assert.Nil(t, missingAttackTrackControl.GetAllAttackTrackCategories())
 
 	// Case: control that has "attackTracks" but it's an empty list
-	emptyAttackTrackJson := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"],"attackTracks":[]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	emptyAttackTrackJson := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"attackTracks":[]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var emptyAttackTrackControl Control
 	err = json.Unmarshal([]byte(emptyAttackTrackJson), &emptyAttackTrackControl)
 	assert.NoError(t, err)
@@ -180,13 +180,13 @@ func TestControl_GetAllAttackTracks(t *testing.T) {
 }
 
 func TestControl_GetControlTypeTags(t *testing.T) {
-	validControlJson := `{"name":"TEST","attributes":{"armoBuiltin":true,"controlTypeTags":["security","compliance"],"attackTracks":{"container":["Privilege escalation"]}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	validControlJson := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"attackTracks":{"container":["Privilege escalation"]}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var validControl Control
 	err := json.Unmarshal([]byte(validControlJson), &validControl)
 	assert.NoError(t, err, err)
 	assert.Equal(t, []string{"security", "compliance"}, validControl.GetControlTypeTags())
 
-	missingAttributeControlJson := `{"name":"TEST","attributes":{"armoBuiltin":true,"attackTracks":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	missingAttributeControlJson := `{"name":"TEST","attributes":{"attackTracks":{"container": "x"}},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
 	var missingAttributeControl Control
 	err = json.Unmarshal([]byte(missingAttributeControlJson), &missingAttributeControl)
 	assert.NoError(t, err, err)


### PR DESCRIPTION
## type:
Refactoring

___
## description:
This PR primarily focuses on the refactoring of test cases in the 'datastructuresmethods_test.go' file. The "armoBuiltin" attribute has been removed from the JSON strings used in the test cases. This attribute was previously part of the "attributes" field in the JSON strings. The changes are applied across multiple test functions, including 'TestControl_GetAttackTrackCategories', 'TestControl_GetAllAttackTracks', and 'TestControl_GetControlTypeTags'.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `reporthandling/datastructuresmethods_test.go`: The "armoBuiltin" attribute has been removed from the JSON strings used in the test cases. The changes are applied across multiple test functions, including 'TestControl_GetAttackTrackCategories', 'TestControl_GetAllAttackTracks', and 'TestControl_GetControlTypeTags'.
</details>
