### PR TITLE
feat: Add Vulnerability scanning report to the summaryDetails section

### DIFF
--- a/reporthandling/results/v1/reportsummary/datastructures.go
+++ b/reporthandling/results/v1/reportsummary/datastructures.go
@@ -80,33 +80,33 @@ type PostureCounters struct {
 }
 
 type VulnerabilitySummary struct {
-	MapsSeverityToSummary MapsSeverityToSummary `json:"MapsSeverityToSummary"`
+	MapsSeverityToSummary MapsSeverityToSummary `json:"mapsSeverityToSummary"`
 	CVESummary            []CVESummary          `json:"CVEs"`
-	PackageScores         PackageScores         `json:"PackageScores"`
-	Images                []string              `json:"Images"`
+	PackageScores         PackageScores         `json:"packageScores"`
+	Images                []string              `json:"images"`
 }
 
 type MapsSeverityToSummary map[string]*SeveritySummary
 
 type SeveritySummary struct {
-	NumberOfCVEs        int `json:"NumberOfCVEs"`
-	NumberOfFixableCVEs int `json:"NumberOfFixableCVEs"`
+	NumberOfCVEs        int `json:"numberOfCVEs"`
+	NumberOfFixableCVEs int `json:"numberOfFixableCVEs"`
 }
 
 type CVESummary struct {
-	Severity    string   `json:"Severity"`
-	ID          string   `json:"ID"`
-	Package     string   `json:"Package"`
-	Version     string   `json:"Version"`
-	FixVersions []string `json:"FixVersions"`
-	FixedState  string   `json:"FixedState"`
+	Severity    string   `json:"severity"`
+	ID          string   `json:"id"`
+	Package     string   `json:"package"`
+	Version     string   `json:"version"`
+	FixVersions []string `json:"fixVersions"`
+	FixedState  string   `json:"fixedState"`
 }
 
 type PackageScores map[string]*PackageSummary
 
 type PackageSummary struct {
-	Name                    string         `json:"Name"`
-	Version                 string         `json:"Version"`
-	Score                   int            `json:"Score"`
-	MapSeverityToCVEsNumber map[string]int `json:"MapSeverityToCVEsNumber"`
+	Name                    string         `json:"name"`
+	Version                 string         `json:"version"`
+	Score                   int            `json:"score"`
+	MapSeverityToCVEsNumber map[string]int `json:"mapSeverityToCVEsNumber"`
 }

--- a/reporthandling/results/v1/reportsummary/datastructures.go
+++ b/reporthandling/results/v1/reportsummary/datastructures.go
@@ -15,14 +15,15 @@ type ControlSummaries map[string]ControlSummary
 
 // SummaryDetails detailed summary of the scanning. will contain versions, counters, etc.
 type SummaryDetails struct {
-	Controls                  ControlSummaries    `json:"controls,omitempty"`
-	Status                    apis.ScanningStatus `json:"status"`
-	Frameworks                []FrameworkSummary  `json:"frameworks"`
-	ResourcesSeverityCounters SeverityCounters    `json:"resourcesSeverityCounters,omitempty"`
-	ControlsSeverityCounters  SeverityCounters    `json:"controlsSeverityCounters,omitempty"`
-	StatusCounters            StatusCounters      `json:"ResourceCounters"` // Backward compatibility
-	Score                     float32             `json:"score"`
-	ComplianceScore           float32             `json:"complianceScore"`
+	Controls                  ControlSummaries     `json:"controls,omitempty"`
+	Status                    apis.ScanningStatus  `json:"status"`
+	Frameworks                []FrameworkSummary   `json:"frameworks"`
+	ResourcesSeverityCounters SeverityCounters     `json:"resourcesSeverityCounters,omitempty"`
+	ControlsSeverityCounters  SeverityCounters     `json:"controlsSeverityCounters,omitempty"`
+	StatusCounters            StatusCounters       `json:"ResourceCounters"` // Backward compatibility
+	Vulnerabilities           VulnerabilitySummary `json:"vulnerabilities,omitempty"`
+	Score                     float32              `json:"score"`
+	ComplianceScore           float32              `json:"complianceScore"`
 }
 
 // FrameworkSummary summary of scanning from a single framework perspective
@@ -76,4 +77,36 @@ type PostureCounters struct {
 	FailedCounter   int `json:"failed"`
 	SkippedCounter  int `json:"skipped"`
 	ExcludedCounter int `json:"excluded"` // Deprecated
+}
+
+type VulnerabilitySummary struct {
+	MapsSeverityToSummary MapsSeverityToSummary `json:"MapsSeverityToSummary"`
+	CVESummary            []CVESummary          `json:"CVEs"`
+	PackageScores         PackageScores         `json:"PackageScores"`
+	Images                []string              `json:"Images"`
+}
+
+type MapsSeverityToSummary map[string]*SeveritySummary
+
+type SeveritySummary struct {
+	NumberOfCVEs        int `json:"NumberOfCVEs"`
+	NumberOfFixableCVEs int `json:"NumberOfFixableCVEs"`
+}
+
+type CVESummary struct {
+	Severity    string   `json:"Severity"`
+	ID          string   `json:"ID"`
+	Package     string   `json:"Package"`
+	Version     string   `json:"Version"`
+	FixVersions []string `json:"FixVersions"`
+	FixedState  string   `json:"FixedState"`
+}
+
+type PackageScores map[string]*PackageSummary
+
+type PackageSummary struct {
+	Name                    string         `json:"Name"`
+	Version                 string         `json:"Version"`
+	Score                   int            `json:"Score"`
+	MapSeverityToCVEsNumber map[string]int `json:"MapSeverityToCVEsNumber"`
 }


### PR DESCRIPTION
## **User description**
Related to the issue https://github.com/kubescape/kubescape/issues/1601 and complementing the PR https://github.com/kubescape/kubescape/pull/1615, includes the data structure changes needed to return a new `vulnerabilities` section in the SumaryDetails.


___

## **Type**
enhancement


___

## **Description**
- Added a new `Vulnerabilities` section in `SummaryDetails` to enhance the scanning report with detailed vulnerability information.
- The new section includes severity mapping, CVE details, package scores, and a list of affected images, providing a comprehensive overview of vulnerabilities.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>datastructures.go</strong><dd><code>Integrate Vulnerability Scanning Report into SummaryDetails</code></dd></summary>
<hr>

reporthandling/results/v1/reportsummary/datastructures.go
<li>Added <code>Vulnerabilities</code> field to <code>SummaryDetails</code> struct to include <br>vulnerability scanning report.<br> <li> Introduced <code>VulnerabilitySummary</code> struct with details on severity <br>mapping, CVE summaries, package scores, and affected images.<br> <li> Defined <code>MapsSeverityToSummary</code>, <code>SeveritySummary</code>, <code>CVESummary</code>, and <br><code>PackageScores</code> structs for detailed vulnerability reporting.


</details>
    

  </td>
  <td><a href="https:/kubescape/opa-utils/pull/148/files#diff-900ffa18b74c425358f79f6857bfc3b85fc1bbd28c3fa31d52dccc0cc9bbb16f">+41/-8</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

