### PR TITLE
Fixed exceptions in vector objects

### DIFF
--- a/exceptions/comparator_test.go
+++ b/exceptions/comparator_test.go
@@ -1,0 +1,393 @@
+package exceptions
+
+import (
+	"testing"
+
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/objectsenvelopes/localworkload"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComparator_compareNamespace(t *testing.T) {
+	c := &comparator{} // Assuming you have initialized the comparator instance
+
+	tests := []struct {
+		name      string
+		workload  workloadinterface.IMetadata
+		namespace string
+		expected  bool
+	}{
+		{
+			name: "Workload kind is Namespace, regex match",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "test-namespace",
+					},
+				},
+			),
+			namespace: "test-namespace",
+			expected:  true,
+		},
+		{
+			name: "Workload kind is Namespace, regex does not match",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "test-namespace",
+					},
+				},
+			),
+			namespace: "different-namespace",
+			expected:  false,
+		},
+		{
+			name: "Workload kind is not Namespace, regex match",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+				},
+			),
+			namespace: "test-namespace",
+			expected:  true,
+		},
+		{
+			name: "Workload kind is not Namespace, regex does not match",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "different-namespace",
+					},
+				},
+			),
+			namespace: "test-namespace",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, c.compareNamespace(tt.workload, tt.namespace))
+		})
+	}
+}
+func TestComparator_compareKind(t *testing.T) {
+	c := &comparator{} // Assuming you have initialized the comparator instance
+
+	tests := []struct {
+		name     string
+		workload workloadinterface.IMetadata
+		kind     string
+		expected bool
+	}{
+		{
+			name: "Kind matches",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+				},
+			),
+			kind:     "Deployment",
+			expected: true,
+		},
+		{
+			name: "Kind does not match",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+				},
+			),
+			kind:     "Pod",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, c.compareKind(tt.workload, tt.kind))
+		})
+	}
+}
+
+func TestComparator_compareName(t *testing.T) {
+	c := &comparator{} // Assuming you have initialized the comparator instance
+
+	tests := []struct {
+		name         string
+		workload     workloadinterface.IMetadata
+		workloadName string
+		expected     bool
+	}{
+		{
+			name: "Name matches",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+				},
+			),
+			workloadName: "test",
+			expected:     true,
+		},
+		{
+			name: "Name does not match",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+				},
+			),
+			workloadName: "different",
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, c.compareName(tt.workload, tt.workloadName))
+		})
+	}
+}
+func TestComparator_comparePath(t *testing.T) {
+	c := &comparator{} // Assuming you have initialized the comparator instance
+
+	tests := []struct {
+		name     string
+		workload workloadinterface.IMetadata
+		path     string
+		expected bool
+	}{
+		{
+			name: "Workload has sourcePath, regex match",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+					"sourcePath": "/test/path",
+				},
+			),
+			path:     "/test/path",
+			expected: true,
+		},
+		{
+			name: "Workload has sourcePath, regex does not match",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+					"sourcePath": "/test/path",
+				},
+			),
+			path:     "/different/path",
+			expected: false,
+		},
+		{
+			name: "Workload does not have sourcePath",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+				},
+			),
+			path:     "/test/path",
+			expected: false,
+		},
+		{
+			name: "Not a workload",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"kind": "Something",
+					"name": "test",
+				},
+			),
+			path:     "/test/path",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, c.comparePath(tt.workload, tt.path))
+		})
+	}
+}
+
+func TestIsTypeWorkload(t *testing.T) {
+	tests := []struct {
+		workload workloadinterface.IMetadata
+		name     string
+		expected bool
+	}{
+		{
+			name: "Workload type is WorkloadObject",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+				},
+			),
+			expected: true,
+		},
+		{
+			name: "Workload type is ListWorkloads",
+			workload: workloadinterface.NewListWorkloadsObj(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "List",
+					"metadata": map[string]interface{}{
+						"namespace": "test-namespace",
+					},
+					"items": []interface{}{},
+				},
+			),
+			expected: true,
+		},
+		{
+			name: "Workload type is BaseObject",
+			workload: workloadinterface.NewBaseObject(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "test",
+					},
+				},
+			),
+			expected: true,
+		},
+		{
+			name: "Workload type is LocalWorkload",
+			workload: localworkload.NewLocalWorkload(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+					},
+					"sourcePath": "/test/path",
+				},
+			),
+			expected: true,
+		},
+		{
+			name: "Workload type is not a recognized type",
+			workload: workloadinterface.NewWorkloadObj(
+				map[string]interface{}{
+					"objectType": "UnrecognizedType",
+				},
+			),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTypeWorkload(tt.workload))
+		})
+	}
+}
+
+func TestIsTypeRegoResponseVector(t *testing.T) {
+	tests := []struct {
+		workload workloadinterface.IMetadata
+		name     string
+		expected bool
+	}{
+		{
+			name: "Workload type is RegoResponseVectorObject",
+			workload: objectsenvelopes.NewRegoResponseVectorObject(
+				map[string]interface{}{
+					"kind": "RegoResponseVector",
+					"name": "test",
+					"relatedObjects": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test-namespace",
+							},
+						},
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test-2",
+								"namespace": "test-namespace",
+							},
+						},
+					},
+				},
+			),
+			expected: true,
+		},
+		{
+			name: "Workload type is not RegoResponseVectorObject",
+			workload: workloadinterface.NewBaseObject(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Namespace",
+					"metadata": map[string]interface{}{
+						"name": "test",
+					},
+				},
+			),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTypeRegoResponseVector(tt.workload))
+		})
+	}
+}

--- a/exceptions/designators_cache.go
+++ b/exceptions/designators_cache.go
@@ -1,8 +1,9 @@
 package exceptions
 
 import (
-	"github.com/armosec/armoapi-go/identifiers"
 	"sync"
+
+	"github.com/armosec/armoapi-go/identifiers"
 
 	"github.com/kubescape/opa-utils/exceptions/internal/hashmap"
 )
@@ -13,8 +14,8 @@ type (
 	// We use a plain map with mutex instead of sync.Map, so we may preallocate
 	// a few slots for designators.
 	designatorCache struct {
-		mx       sync.RWMutex
 		innerMap map[portalDesignatorKey]identifiers.AttributesDesignators
+		mx       sync.RWMutex
 	}
 
 	portalDesignatorKey struct {

--- a/exceptions/exceptionprocessor.go
+++ b/exceptions/exceptionprocessor.go
@@ -174,7 +174,10 @@ func (p *Processor) hasException(clusterName string, designator *identifiers.Por
 	}
 
 	if isTypeRegoResponseVector(workload) {
-		return p.iterateRegoResponseVector(workload, attributes)
+		if p.iterateRegoResponseVector(workload, attributes) {
+			return true
+		}
+		// otherwise, continue to check the base object
 	}
 	return p.metadataHasException(workload, attributes)
 

--- a/exceptions/exceptionprocessor_test.go
+++ b/exceptions/exceptionprocessor_test.go
@@ -818,6 +818,142 @@ func TestHasException(t *testing.T) {
 			),
 			expected: true,
 		},
+		{
+			name: "Test case: Name matches in base object",
+			workload: objectsenvelopes.NewRegoResponseVectorObject(
+				map[string]interface{}{
+					"kind": "RegoResponseVector",
+					"name": "base",
+					"relatedObjects": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test-namespace",
+							},
+						},
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test-2",
+								"namespace": "test-namespace",
+							},
+						},
+					},
+				},
+			),
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes: map[string]string{
+					"name": "base",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Test case: Kind matches in base object",
+			workload: objectsenvelopes.NewRegoResponseVectorObject(
+				map[string]interface{}{
+					"kind": "RegoResponseVector",
+					"name": "base",
+					"relatedObjects": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test-namespace",
+							},
+						},
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test-2",
+								"namespace": "test-namespace",
+							},
+						},
+					},
+				},
+			),
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes: map[string]string{
+					"kind": "RegoResponseVector",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Test case: Name mismatches in base object",
+			workload: objectsenvelopes.NewRegoResponseVectorObject(
+				map[string]interface{}{
+					"kind": "ServiceAccount",
+					"name": "base",
+					"relatedObjects": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test-namespace",
+							},
+						},
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test-2",
+								"namespace": "test-namespace",
+							},
+						},
+					},
+				},
+			),
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes: map[string]string{
+					"name": "base-2",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Test case: Kind mismatches in base object",
+			workload: objectsenvelopes.NewRegoResponseVectorObject(
+				map[string]interface{}{
+					"kind": "ServiceAccount",
+					"name": "base",
+					"relatedObjects": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test-namespace",
+							},
+						},
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"name":      "test-2",
+								"namespace": "test-namespace",
+							},
+						},
+					},
+				},
+			),
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes: map[string]string{
+					"kind": "RegoResponseVector",
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## **User description**
* Fixed: Exceptions did not apply to the workloads in the `RegoResponseVectorObject`
* Fixed: Exceptions where applied on `RegoResponseVectorObject` objects when the exception had a label (also if the label was not in the vector)
* Unit tests: Increase coverage


___

## **Type**
bug_fix, enhancement, tests


___

## **Description**
- Refactored workload type checks to remove dependency on `k8s-interface` and utilize `objectsenvelopes` and `localworkload`.
- Simplified label and annotation comparison logic in `comparator.go`.
- Introduced new functions `isTypeWorkload` and `isTypeRegoResponseVector` for accurate type determination.
- Enhanced exception processing to support `RegoResponseVector` objects, optimizing the handling of exceptions.
- Added comprehensive unit tests for new and existing logic in `comparator` and `exceptionprocessor`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comparator.go</strong><dd><code>Refactor Workload Type Checks and Simplify Comparisons</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exceptions/comparator.go
<li>Removed dependency on <code>k8s-interface</code> for workload type checks.<br> <li> Added <code>objectsenvelopes</code> and <code>localworkload</code> for enhanced type checks.<br> <li> Simplified label and annotation comparison logic.<br> <li> Introduced <code>isTypeWorkload</code> and <code>isTypeRegoResponseVector</code> functions for <br>precise type determination.


</details>
    

  </td>
  <td><a href="https:/kubescape/opa-utils/pull/149/files#diff-43e75d4c442482eea4a8633909b1ce4401289e23fcb674411c4fc1d655b75019">+30/-27</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>exceptionprocessor.go</strong><dd><code>Enhance Exception Processing and Comparison Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exceptions/exceptionprocessor.go
<li>Enhanced exception processing to support <code>RegoResponseVector</code> objects.<br> <li> Optimized label and annotation comparison logic.<br> <li> Introduced <code>metadataHasException</code> and <code>iterateRegoResponseVector</code> for <br>improved exception handling.


</details>
    

  </td>
  <td><a href="https:/kubescape/opa-utils/pull/149/files#diff-c69565181a6101110c5cc8a50b64fd30879be3eaf05c66889af221e352faf3ac">+25/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comparator_test.go</strong><dd><code>Comprehensive Unit Tests for Comparator Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exceptions/comparator_test.go
<li>Added extensive unit tests for <code>comparator</code> methods.<br> <li> Tested new type check functions <code>isTypeWorkload</code> and <br><code>isTypeRegoResponseVector</code>.<br> <li> Ensured compatibility with new comparison logic through various test <br>cases.


</details>
    

  </td>
  <td><a href="https:/kubescape/opa-utils/pull/149/files#diff-a2e1d745deb806eeb9acb2427fbe53b497673c147b40e92242c15c84f19c5209">+393/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>exceptionprocessor_test.go</strong><dd><code>Unit Tests for Enhanced Exception Processing Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exceptions/exceptionprocessor_test.go
<li>Added tests for <code>hasException</code> method with various scenarios.<br> <li> Included tests for new methods handling <code>RegoResponseVector</code> objects.


</details>
    

  </td>
  <td><a href="https:/kubescape/opa-utils/pull/149/files#diff-9f26b2e5b62f900ffc7b6dae5a4bfb83a72bc20730198df11ed84b2409832667">+806/-13</a></td>
</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>designators_cache.go</strong><dd><code>Code Reorganization in Designators Cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

exceptions/designators_cache.go
- Minor code reorganization for readability.
- No functional changes.


</details>
    

  </td>
  <td><a href="https:/kubescape/opa-utils/pull/149/files#diff-b267732a2f8c3f51e60209d7c3e09c7c44c1f47f408ccde660ab43e7f5e07280">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

