### PR TITLE
add func IsFixedByNetworkPolicy

### DIFF
--- a/reporthandling/datastructuresmethods.go
+++ b/reporthandling/datastructuresmethods.go
@@ -12,7 +12,10 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-const ActionRequiredAttribute string = "actionRequired"
+const (
+	ActionRequiredAttribute                   string = "actionRequired"
+	ControlAttributeKeyIsFixedByNetworkPolicy string = "isFixedByNetworkPolicy"
+)
 
 // ==============================================================================================
 // ========================== PostureReport =====================================================
@@ -441,6 +444,19 @@ func (control *Control) GetControlTypeTags() []string {
 		}
 	}
 	return []string{}
+}
+
+// returns true if control has attribute "isFixedByNetworkPolicy" and its value is true
+func (control *Control) IsFixedByNetworkPolicy() bool {
+	if control.Attributes == nil {
+		return false
+	}
+	if v, exist := control.Attributes[ControlAttributeKeyIsFixedByNetworkPolicy]; exist {
+		if isFixedByNetworkPolicy, ok := v.(bool); ok {
+			return isFixedByNetworkPolicy
+		}
+	}
+	return false
 }
 
 func (control *Control) SupportSmartRemediation() bool {

--- a/reporthandling/datastructuresmethods_test.go
+++ b/reporthandling/datastructuresmethods_test.go
@@ -192,3 +192,22 @@ func TestControl_GetControlTypeTags(t *testing.T) {
 	assert.NoError(t, err, err)
 	assert.Equal(t, []string{}, missingAttributeControl.GetControlTypeTags())
 }
+
+func TestControl_IsFixedByNetworkPolicy(t *testing.T) {
+	validControlJsonNoAttributes := `{"name":"TEST","description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	var validControl Control
+	err := json.Unmarshal([]byte(validControlJsonNoAttributes), &validControl)
+	assert.NoError(t, err, err)
+	assert.False(t, validControl.IsFixedByNetworkPolicy())
+
+	validControlJson := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"],"isFixedByNetworkPolicy":true, "attackTracks":[{"attackTrack": "network","categories": ["Eavesdropping","Spoofing"]}]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	err = json.Unmarshal([]byte(validControlJson), &validControl)
+	assert.NoError(t, err, err)
+	assert.True(t, validControl.IsFixedByNetworkPolicy())
+
+	missingAttributeControlJson := `{"name":"TEST","attributes":{"controlTypeTags":["security","compliance"]},"description":"","remediation":"","rulesNames":["CVE-2022-0185"],"id":"C-0079","long_description":"","test":"","controlID":"C-0079","baseScore":4,"example":""}`
+	var missingAttributeControl Control
+	err = json.Unmarshal([]byte(missingAttributeControlJson), &missingAttributeControl)
+	assert.NoError(t, err, err)
+	assert.False(t, missingAttributeControl.IsFixedByNetworkPolicy())
+}


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new constant and method to enhance the `Control` struct functionality:
  - `ControlAttributeKeyIsFixedByNetworkPolicy` constant for the attribute key.
  - `IsFixedByNetworkPolicy()` method to evaluate if a control is fixed by a network policy, enhancing control analysis capabilities.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>datastructuresmethods.go</strong><dd><code>Add Method to Check if Control is Fixed by Network Policy</code></dd></summary>
<hr>

reporthandling/datastructuresmethods.go
<li>Introduced a new constant <code>ControlAttributeKeyIsFixedByNetworkPolicy</code> to <br>represent the attribute key for checking if a control is fixed by a <br>network policy.<br> <li> Added a new method <code>IsFixedByNetworkPolicy()</code> to the <code>Control</code> struct to <br>check if the control is fixed by a network policy.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/opa-utils/pull/151/files#diff-f9690e8401fc7f1aed64bf8fb0c2b254a821e5f009fab1a8b94ab2314bf7831e">+17/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

