### PR TITLE
Replace `golang.org/x/exp` with stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/open-policy-agent/opa v0.61.0
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
@@ -138,6 +137,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.19.0 // indirect
+	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect

--- a/reporthandling/datastructuresmethods.go
+++ b/reporthandling/datastructuresmethods.go
@@ -3,13 +3,13 @@ package reporthandling
 import (
 	"fmt"
 	"hash/fnv"
+	"slices"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/kubescape/opa-utils/reporthandling/apis"
 	"github.com/kubescape/opa-utils/reporthandling/attacktrack/v1alpha1"
 	"github.com/mitchellh/mapstructure"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/reporthandling/helpers/v1/listing.go
+++ b/reporthandling/helpers/v1/listing.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	"github.com/kubescape/opa-utils/reporthandling/apis"
-	"golang.org/x/exp/maps"
 )
 
 var allListsPool = &sync.Pool{
@@ -62,7 +61,7 @@ func (all *AllLists) Initialize(size int) {
 // Clear remove all items and reset the counters
 func (all *AllLists) Clear() {
 	if all.itemToStatus != nil {
-		maps.Clear(all.itemToStatus)
+		clear(all.itemToStatus)
 		all.passed = 0
 		all.failed = 0
 		all.skipped = 0


### PR DESCRIPTION
The experimental functions in `golang.org/x/exp/slices` are now available in the standard library in Go 1.21.

The new built-in function `clear` is the replacement for `maps.Clear` from `golang.org/x/exp/maps`.

Reference: https://go.dev/doc/go1.21#slices
Reference: https://go.dev/ref/spec#Clear