### PR TITLE
fix(score): return 100% compliance for skipped controls with exceptions

### DIFF
--- a/score/score.go
+++ b/score/score.go
@@ -428,8 +428,7 @@ func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummar
 		return 100
 	}
 
-	// If a control is skipped due to an exception (e.g. manual controls with an exception applied),
-	// treat it as 100% compliant since the user has explicitly acknowledged it.
+	// If a control is skipped with an exception (e.g. a manual control), treat it as 100% compliant.
 	if ctrl.GetStatus().IsSkipped() && ctrl.GetSubStatus() == apis.SubStatusException {
 		return 100
 	}

--- a/score/score.go
+++ b/score/score.go
@@ -428,6 +428,12 @@ func (su *ScoreUtil) GetControlComplianceScore(ctrl reportsummary.IControlSummar
 		return 100
 	}
 
+	// If a control is skipped due to an exception (e.g. manual controls with an exception applied),
+	// treat it as 100% compliant since the user has explicitly acknowledged it.
+	if ctrl.GetStatus().IsSkipped() && ctrl.GetSubStatus() == apis.SubStatusException {
+		return 100
+	}
+
 	resourcesIDs := ctrl.ListResourcesIDs(nil)
 	numOfPassedResources := resourcesIDs.Passed()
 	numOfAllResources := resourcesIDs.Len()

--- a/score/score_test.go
+++ b/score/score_test.go
@@ -912,6 +912,26 @@ func TestGetControlComplianceScore(t *testing.T) {
 			"control report should return a score equals to 50",
 		)
 	})
+
+	t.Run("skipped control with exception", func(t *testing.T) {
+		t.Parallel()
+
+		resources := mockResources(t)
+		s := ScoreUtil{isDebugMode: true, resources: resources}
+		controlReport := reportsummary.ControlSummary{
+			Name:      "manual-control-with-exception",
+			ControlID: "C-0286",
+			StatusInfo: apis.StatusInfo{
+				InnerStatus: apis.StatusSkipped,
+				SubStatus:   apis.SubStatusException,
+			},
+			ResourceIDs: helpers.AllLists{},
+		}
+
+		require.Equal(t, float32(100), s.GetControlComplianceScore(&controlReport, ""),
+			"skipped control with exception should return a score equals to 100",
+		)
+	})
 }
 
 func TestSetPostureReportComplianceScores(t *testing.T) {


### PR DESCRIPTION
## Overview

`GetControlComplianceScore` returned 0 for skipped controls with no resources, even
when `subStatus=w/exceptions`. Added a check to return 100 when a skipped control has
`SubStatusException` — the user has explicitly acknowledged it.

**Before:** skipped + w/exceptions → complianceScore 0%
**After:** skipped + w/exceptions → complianceScore 100%

## Related issues/PRs

* Part of kubescape/kubescape#1893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated compliance score calculation: skipped controls with exception status are now treated as fully compliant with a score of 100.

* **Tests**
  * Added unit test coverage to verify that skipped controls with exception status receive a full compliance score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->