### PR TITLE
feat(exceptions): add cluster-matching and control-ID helpers for external callers

### DIFF
--- a/exceptions/exceptionprocessor.go
+++ b/exceptions/exceptionprocessor.go
@@ -152,7 +152,13 @@ func (p *Processor) GetResourceExceptions(ruleExceptions []armotypes.PostureExce
 	return postureExceptionPolicy
 }
 
-// MatchesCluster returns true if the designator has no cluster constraint, or if its cluster constraint matches clusterName.
+// RegexCompareControlID reports whether pattern case-insensitively matches target.
+func (p *Processor) RegexCompareControlID(pattern, target string) bool {
+	return p.regexCompareI(pattern, target)
+}
+
+// MatchesCluster reports whether the designator's cluster constraint matches clusterName.
+// A nil designator or empty cluster field matches any cluster.
 func (p *Processor) MatchesCluster(designator *identifiers.PortalDesignator, clusterName string) bool {
 	if designator == nil {
 		return true
@@ -160,7 +166,7 @@ func (p *Processor) MatchesCluster(designator *identifiers.PortalDesignator, clu
 	return p.matchesCluster(p.getAttributes(designator), clusterName)
 }
 
-// getAttributes returns digested attributes for a designator, using the cache when available.
+// getAttributes returns digested attributes, using the cache when available.
 func (p *Processor) getAttributes(designator *identifiers.PortalDesignator) identifiers.AttributesDesignators {
 	if attrs, ok := p.designatorCache.Get(designator); ok {
 		return attrs
@@ -170,7 +176,7 @@ func (p *Processor) getAttributes(designator *identifiers.PortalDesignator) iden
 	return attrs
 }
 
-// matchesCluster checks the cluster constraint against already-digested attributes.
+// matchesCluster checks the cluster constraint against pre-digested attributes.
 func (p *Processor) matchesCluster(attributes identifiers.AttributesDesignators, clusterName string) bool {
 	cluster := attributes.GetCluster()
 	if cluster == "" {

--- a/exceptions/exceptionprocessor.go
+++ b/exceptions/exceptionprocessor.go
@@ -152,6 +152,15 @@ func (p *Processor) GetResourceExceptions(ruleExceptions []armotypes.PostureExce
 	return postureExceptionPolicy
 }
 
+// MatchesCluster returns true if the designator has no cluster constraint, or if its cluster constraint matches clusterName.
+func (p *Processor) MatchesCluster(designator *identifiers.PortalDesignator, clusterName string) bool {
+	cluster := designator.GetCluster()
+	if cluster == "" {
+		return true
+	}
+	return p.compareCluster(cluster, clusterName)
+}
+
 // compareMetadata - compare namespace and kind
 func (p *Processor) hasException(clusterName string, designator *identifiers.PortalDesignator, workload workloadinterface.IMetadata) bool {
 	var attributes identifiers.AttributesDesignators
@@ -167,7 +176,7 @@ func (p *Processor) hasException(clusterName string, designator *identifiers.Por
 		return false // if designators are empty
 	}
 
-	if attributes.GetCluster() != "" && !p.compareCluster(attributes.GetCluster(), clusterName) { // TODO - where do we receive cluster name from?
+	if !p.MatchesCluster(designator, clusterName) {
 		return false // cluster name does not match
 	}
 

--- a/exceptions/exceptionprocessor.go
+++ b/exceptions/exceptionprocessor.go
@@ -154,7 +154,25 @@ func (p *Processor) GetResourceExceptions(ruleExceptions []armotypes.PostureExce
 
 // MatchesCluster returns true if the designator has no cluster constraint, or if its cluster constraint matches clusterName.
 func (p *Processor) MatchesCluster(designator *identifiers.PortalDesignator, clusterName string) bool {
-	cluster := designator.GetCluster()
+	if designator == nil {
+		return true
+	}
+	return p.matchesCluster(p.getAttributes(designator), clusterName)
+}
+
+// getAttributes returns digested attributes for a designator, using the cache when available.
+func (p *Processor) getAttributes(designator *identifiers.PortalDesignator) identifiers.AttributesDesignators {
+	if attrs, ok := p.designatorCache.Get(designator); ok {
+		return attrs
+	}
+	attrs := designator.DigestPortalDesignator()
+	p.designatorCache.Set(designator, attrs)
+	return attrs
+}
+
+// matchesCluster checks the cluster constraint against already-digested attributes.
+func (p *Processor) matchesCluster(attributes identifiers.AttributesDesignators, clusterName string) bool {
+	cluster := attributes.GetCluster()
 	if cluster == "" {
 		return true
 	}
@@ -163,20 +181,13 @@ func (p *Processor) MatchesCluster(designator *identifiers.PortalDesignator, clu
 
 // compareMetadata - compare namespace and kind
 func (p *Processor) hasException(clusterName string, designator *identifiers.PortalDesignator, workload workloadinterface.IMetadata) bool {
-	var attributes identifiers.AttributesDesignators
-	if attrs, ok := p.designatorCache.Get(designator); ok {
-		attributes = attrs
-	} else {
-		attrs := designator.DigestPortalDesignator()
-		attributes = attrs
-		p.designatorCache.Set(designator, attributes)
-	}
+	attributes := p.getAttributes(designator)
 
 	if attributes.GetCluster() == "" && attributes.GetNamespace() == "" && attributes.GetKind() == "" && attributes.GetName() == "" && attributes.GetResourceID() == "" && attributes.GetPath() == "" && len(attributes.GetLabels()) == 0 {
 		return false // if designators are empty
 	}
 
-	if !p.MatchesCluster(designator, clusterName) {
+	if !p.matchesCluster(attributes, clusterName) {
 		return false // cluster name does not match
 	}
 


### PR DESCRIPTION
## Overview

Add three exported helpers on `Processor` to support the manual-control exception path in kubescape:

- `MatchesCluster` — nil-safe cluster designator check; delegates to private `matchesCluster`
- `RegexCompareControlID` — case-insensitive regex match for control IDs
- `getAttributes` / `matchesCluster` — private helpers that centralise the designator cache lookup and cluster check, removing the redundant lookup in `hasException` and the existing TODO comment

## How to Test

No behaviour change — refactor only.

```
go test ./exceptions/... -count=1
```

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes