### PR TITLE
feat(apis): add SubStatusNotEvaluated for missing-GVR skips

### DIFF
--- a/reporthandling/apis/statuses.go
+++ b/reporthandling/apis/statuses.go
@@ -14,6 +14,7 @@ const (
 	SubStatusIntegration    ScanningSubStatus = "integration"
 	SubStatusRequiresReview ScanningSubStatus = "requires review"
 	SubStatusManualReview   ScanningSubStatus = "manual review"
+	SubStatusNotEvaluated   ScanningSubStatus = "notEvaluated"
 	SubStatusUnknown        ScanningSubStatus = "" // keep this empty
 	StatusUnknown           ScanningStatus    = "" // keep this empty
 
@@ -25,6 +26,7 @@ const (
 	SubStatusConfigurationInfo  StatusMsg = "Control configurations are empty (docs: https://kubescape.io/docs/frameworks-and-controls/configuring-controls)"
 	SubStatusRequiresReviewInfo StatusMsg = "Control type is requires-review"
 	SubStatusManualReviewInfo   StatusMsg = "Control type is manual-review"
+	SubStatusNotEvaluatedInfo   StatusMsg = "Control was not evaluated because required resource types could not be collected"
 )
 
 // IStatus interface handling status
@@ -70,8 +72,8 @@ func Compare(a, b ScanningStatus) ScanningStatus {
 		1. status=failed or status=unknown:
 			sub status = ""
 		2. status=skipped:
-			if aSub or bSub are configuration/integration/review:
-				sub status = aSub or bSub
+			if aSub or bSub are notEvaluated/configuration/integration/review:
+				sub status = aSub or bSub (notEvaluated takes precedence)
 			else:
 				sub status = status=unknown
 		3. status=passed:
@@ -94,6 +96,9 @@ func CompareStatusAndSubStatus(a, b ScanningStatus, aSub, bSub ScanningSubStatus
 		}
 
 	case StatusSkipped:
+		if aSub == SubStatusNotEvaluated || bSub == SubStatusNotEvaluated {
+			return status, SubStatusNotEvaluated
+		}
 		if aSub == SubStatusConfiguration || bSub == SubStatusConfiguration {
 			return status, SubStatusConfiguration
 		}

--- a/reporthandling/apis/statuses_test.go
+++ b/reporthandling/apis/statuses_test.go
@@ -29,6 +29,13 @@ func TestCompareStatusAndSubStatus(t *testing.T) {
 	assert.Equal(t, makeIS(StatusSkipped, SubStatusIntegration), makeIS(CompareStatusAndSubStatus(StatusSkipped, StatusPassed, SubStatusIntegration, SubStatusUnknown)))
 	assert.Equal(t, makeIS(StatusSkipped, SubStatusManualReview), makeIS(CompareStatusAndSubStatus(StatusPassed, StatusSkipped, SubStatusUnknown, SubStatusManualReview)))
 	assert.Equal(t, makeIS(StatusSkipped, SubStatusRequiresReview), makeIS(CompareStatusAndSubStatus(StatusPassed, StatusSkipped, SubStatusUnknown, SubStatusRequiresReview)))
+
+	// notEvaluated should win over other skipped substatuses since it signals a real cluster/RBAC gap
+	assert.Equal(t, makeIS(StatusSkipped, SubStatusNotEvaluated), makeIS(CompareStatusAndSubStatus(StatusSkipped, StatusPassed, SubStatusNotEvaluated, SubStatusUnknown)))
+	assert.Equal(t, makeIS(StatusSkipped, SubStatusNotEvaluated), makeIS(CompareStatusAndSubStatus(StatusSkipped, StatusSkipped, SubStatusNotEvaluated, SubStatusConfiguration)))
+	assert.Equal(t, makeIS(StatusSkipped, SubStatusNotEvaluated), makeIS(CompareStatusAndSubStatus(StatusSkipped, StatusSkipped, SubStatusManualReview, SubStatusNotEvaluated)))
+	// failed still beats notEvaluated
+	assert.Equal(t, makeIS(StatusFailed, SubStatusUnknown), makeIS(CompareStatusAndSubStatus(StatusFailed, StatusSkipped, SubStatusUnknown, SubStatusNotEvaluated)))
 }
 
 func TestConvertStatusToNewStatus(t *testing.T) {

--- a/reporthandling/results/v1/reportsummary/controlsummarymethods.go
+++ b/reporthandling/results/v1/reportsummary/controlsummarymethods.go
@@ -63,7 +63,10 @@ func (controlSummary *ControlSummary) calculateNSetSubStatus(subStatus apis.Scan
 			controlSummary.StatusInfo.InnerInfo = ""
 		}
 	case apis.StatusSkipped:
-		if subStatus == apis.SubStatusConfiguration || controlSummary.StatusInfo.SubStatus == apis.SubStatusConfiguration {
+		if subStatus == apis.SubStatusNotEvaluated || controlSummary.StatusInfo.SubStatus == apis.SubStatusNotEvaluated {
+			controlSummary.StatusInfo.SubStatus = apis.SubStatusNotEvaluated
+			controlSummary.StatusInfo.InnerInfo = string(apis.SubStatusNotEvaluatedInfo)
+		} else if subStatus == apis.SubStatusConfiguration || controlSummary.StatusInfo.SubStatus == apis.SubStatusConfiguration {
 			controlSummary.StatusInfo.SubStatus = apis.SubStatusConfiguration
 			controlSummary.StatusInfo.InnerInfo = string(apis.SubStatusConfigurationInfo)
 		} else if subStatus == apis.SubStatusManualReview || controlSummary.StatusInfo.SubStatus == apis.SubStatusManualReview {

--- a/reporthandling/results/v1/resourcesresults/controls.go
+++ b/reporthandling/results/v1/resourcesresults/controls.go
@@ -102,8 +102,9 @@ func (control *ResourceAssociatedControl) SetStatus(c reporthandling.Control) {
 		statusInfo = string(apis.SubStatusManualReviewInfo)
 	}
 
-	// If the control type is configuration and the configuration is not set, the status is skipped and the sub status is configuration
-	if actionRequired == apis.SubStatusConfiguration && controlMissingAllConfigurations(control) {
+	// If the control type is configuration and the configuration is not set, the status is skipped and the sub status is configuration.
+	// Do not overwrite notEvaluated: a GVR collection gap takes precedence over a missing-config skip.
+	if actionRequired == apis.SubStatusConfiguration && controlMissingAllConfigurations(control) && subStatus != apis.SubStatusNotEvaluated {
 		status = apis.StatusSkipped
 		subStatus = apis.SubStatusConfiguration
 		statusInfo = string(apis.SubStatusConfigurationInfo)

--- a/reporthandling/results/v1/resourcesresults/controls_test.go
+++ b/reporthandling/results/v1/resourcesresults/controls_test.go
@@ -67,6 +67,14 @@ func TestSetStatus(t *testing.T) {
 	assert.False(t, r6.GetStatus(nil).IsFailed())
 	assert.True(t, r6.GetStatus(nil).IsSkipped())
 
+	// notEvaluated must not be overwritten by configuration even when configs are missing.
+	// A GVR collection gap (RBAC denied, missing CRD) takes precedence over a missing-config skip.
+	r7 := mockResourceAssociatedControlNotEvaluated()
+	r7.SetStatus(*mockControlWithActionRequiredConfiguration())
+	assert.Equal(t, apis.StatusSkipped, r7.GetStatus(nil).Status())
+	assert.Equal(t, apis.SubStatusNotEvaluated, r7.GetSubStatus())
+	assert.True(t, r7.GetStatus(nil).IsSkipped())
+
 }
 
 func TestResourceAssociatedControl_SetName(t *testing.T) {

--- a/reporthandling/results/v1/resourcesresults/datastructures_mock.go
+++ b/reporthandling/results/v1/resourcesresults/datastructures_mock.go
@@ -272,6 +272,27 @@ func mockControlWithActionRequiredManualReview() *reporthandling.Control {
 	}
 }
 
+func mockResourceAssociatedRuleNotEvaluated() *ResourceAssociatedRule {
+	return &ResourceAssociatedRule{
+		Name:                  "ruleNotEvaluated",
+		Status:                apis.StatusSkipped,
+		SubStatus:             apis.SubStatusNotEvaluated,
+		Paths:                 []armotypes.PosturePaths{},
+		Exception:             []armotypes.PostureExceptionPolicy{},
+		ControlConfigurations: nil,
+	}
+}
+
+func mockResourceAssociatedControlNotEvaluated() *ResourceAssociatedControl {
+	return &ResourceAssociatedControl{
+		ControlID: "C-0089",
+		Name:      "0089",
+		ResourceAssociatedRules: []ResourceAssociatedRule{
+			*mockResourceAssociatedRuleNotEvaluated(),
+		},
+	}
+}
+
 // func mockResourceAssociatedRuleWithFWException() *ResourceAssociatedRule {
 // 	return &ResourceAssociatedRule{
 // 		Name:        "ruleB",


### PR DESCRIPTION
## What this does

Adds a new `SubStatusNotEvaluated` skipped substatus so controls that get skipped because their required GVRs could not be collected (RBAC denied, missing CRDs, API errors) can be told apart from controls that were skipped for configuration / review reasons.

Right now everything ends up as a generic `skipped`, which makes it impossible for downstream consumers to filter on the actual cluster-gap case. Free-text `info` is not enough since you can't filter on it cleanly.

## Why this is here and not in kubescape

This is the prerequisite piece for kubescape/kubescape#2010. The kubescape side wants to mark controls as `notEvaluated` when their GVRs fail to pull, but the substatus enum and the precedence logic both live here, so this has to land first.

Once this is released, kubescape will bump the dep and start setting the substatus from its resource collection path.

## Changes

- `reporthandling/apis/statuses.go`: new `SubStatusNotEvaluated` constant + `SubStatusNotEvaluatedInfo` message. Updated `CompareStatusAndSubStatus` so `notEvaluated` wins over the other skipped substatuses, since a real cluster/RBAC gap is more actionable than a configuration or review skip. `failed` still beats `notEvaluated`.
- `reporthandling/results/v1/reportsummary/controlsummarymethods.go`: extended `calculateNSetSubStatus` skipped branch to handle the new substatus when aggregating control summaries.
- `reporthandling/apis/statuses_test.go`: added precedence tests covering the new substatus against the existing skipped ones and against failed.

## Out of scope

- Anything that actually sets the new substatus. That happens in kubescape on top of the existing `InfoMap` work. Kept this PR to enum + precedence only so it's easy to review on its own.

## Notes

- No new external deps.
- Existing tests pass: `go test ./reporthandling/apis/... ./reporthandling/results/...`
- Additive only, doesn't change any existing substatus behavior.

Refs: kubescape/kubescape#2010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Not Evaluated" skipped status to indicate controls not evaluated due to unavailable resources.

* **Improvements**
  * Status comparison now prioritizes "Not Evaluated" among skipped reasons and prevents it from being overwritten by configuration-missing logic.

* **Tests**
  * Added test scenarios validating "Not Evaluated" precedence and preservation.

* **Chores**
  * Extended mock data with "Not Evaluated" examples for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->