### PR TITLE
feat(reporthandling): add CELLanguage constant for CEL rule evaluation

### DIFF
--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -14,6 +14,7 @@ type RuleLanguages string
 const (
 	RegoLanguage  RuleLanguages = "Rego"
 	RegoLanguage2 RuleLanguages = "rego"
+	CELLanguage   RuleLanguages = "CEL"
 )
 
 // RuleMatchObjects defines which objects this rule applied on

--- a/reporthandling/datastructures_mock.go
+++ b/reporthandling/datastructures_mock.go
@@ -260,6 +260,22 @@ func MockRegoPrivilegedPods() string {
 func MockExternalFacingService() string {
 	return "\n\tpackage armo_builtins\n\n\timport data.kubernetes.api.client as client\n\timport data.cautils as cautils\n\ndeny[msga] {\n\n\twl := input[_]\n\tcluster_resource := client.query_all(\n\t\t\"services\"\n\t)\n\n\tlabels := wl.metadata.labels\n\tfiltered_labels := json.remove(labels, [\"pod-template-hash\"])\n    \n#service := cluster_resource.body.items[i]\nservices := [svc | cluster_resource.body.items[i].metadata.namespace == wl.metadata.namespace; svc := cluster_resource.body.items[i]]\nservice := services[_]\nnp_or_lb := {\"NodePort\", \"LoadBalancer\"}\nnp_or_lb[service.spec.type]\ncautils.is_subobject(service.spec.selector,filtered_labels)\n\n    msga := {\n\t\t\"alertMessage\": sprintf(\"%v pod %v  expose external facing service: %v\",[wl.metadata.namespace, wl.metadata.name, service.metadata.name]),\n\t\t\"alertScore\": 2,\n\t\t\"packagename\": \"armo_builtins\",\n\t\t\"alertObject\": {\"srvc\":service}\n\t}\n}\n\t"
 }
+func MockCELRuleA() *PolicyRule {
+	return &PolicyRule{
+		PortalBase: *armotypes.MockPortalBase("aaaaaaaa-aaaa-aaaa-b39b-8665240080af", AMockControlName, nil),
+		Rule: `has(object.spec.containers) && object.spec.containers.all(c,
+	!has(c.securityContext) || !has(c.securityContext.privileged) || c.securityContext.privileged != true)`,
+		RuleLanguage: CELLanguage,
+		Match: []RuleMatchObjects{
+			{
+				APIVersions: []string{"v1"},
+				APIGroups:   []string{"*"},
+				Resources:   []string{"pods"},
+			},
+		},
+	}
+}
+
 func GetRuntimePods() string {
 	return `
     package armo_builtins

--- a/reporthandling/datastructures_test.go
+++ b/reporthandling/datastructures_test.go
@@ -73,6 +73,25 @@ func TestMockFrameworkA(t *testing.T) {
 
 }
 
+func TestRuleLanguagesConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    RuleLanguages
+		expected string
+	}{
+		{"RegoLanguage", RegoLanguage, "Rego"},
+		{"RegoLanguage2", RegoLanguage2, "rego"},
+		{"CELLanguage", CELLanguage, "CEL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.value) != tt.expected {
+				t.Errorf("%s = %q, want %q", tt.name, tt.value, tt.expected)
+			}
+		})
+	}
+}
+
 func TestMockPostureReportA(t *testing.T) {
 	policy := MockPostureReportA()
 	bp, err := json.Marshal(policy)

--- a/reporthandling/datastructures_test.go
+++ b/reporthandling/datastructures_test.go
@@ -92,6 +92,19 @@ func TestRuleLanguagesConstants(t *testing.T) {
 	}
 }
 
+func TestMockCELRuleA(t *testing.T) {
+	celRule := MockCELRuleA()
+	if celRule.RuleLanguage != CELLanguage {
+		t.Errorf("MockCELRuleA RuleLanguage = %q, want %q", celRule.RuleLanguage, CELLanguage)
+	}
+	if celRule.Rule == "" {
+		t.Error("MockCELRuleA Rule should not be empty")
+	}
+	if len(celRule.Match) != 1 {
+		t.Errorf("MockCELRuleA should have 1 Match entry, got %d", len(celRule.Match))
+	}
+}
+
 func TestMockPostureReportA(t *testing.T) {
 	policy := MockPostureReportA()
 	bp, err := json.Marshal(policy)


### PR DESCRIPTION
## Summary

Adds `CELLanguage` to the `RuleLanguages` type so that Kubescape can dispatch CEL-based compliance rules alongside the existing Rego engine.

## Motivation

The [CEL rule engine project](https://github.com/kubescape/kubescape/issues/2001) in Kubescape needs a `CELLanguage` constant to allow `runOPAOnSingleRule()` to switch on CEL rules and route them to a CEL evaluator. Currently only `RegoLanguage` and `RegoLanguage2` exist.

## Changes

- **`reporthandling/datastructures.go`**: Added `CELLanguage RuleLanguages = "CEL"` constant
- **`reporthandling/datastructures_test.go`**: Added `TestRuleLanguagesConstants` table-driven test covering all three language types

## Related

- kubescape/kubescape#2001 — CEL rule engine support (LFX Mentorship 2026 Term 2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CEL (Common Expression Language) as a supported rule language option.
  * Added a sample/mock CEL policy rule for demonstration and testing.

* **Tests**
  * Added test coverage to verify rule language constants and their string representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->