### PR TITLE
feat(reporthandling): add Helm provenance fields to Source

### DIFF
--- a/reporthandling/datastructuresv1.go
+++ b/reporthandling/datastructuresv1.go
@@ -119,6 +119,9 @@ type Source struct {
 	HelmPath               string     `json:"helmPath,omitempty"`               // relative path to helm chart
 	FileType               string     `json:"fileType,omitempty"`               // file type
 	HelmChartName          string     `json:"helmChartName,omitempty"`          // helm chart name (if FileType is "Helm Chart")
+	HelmTemplateFile       string     `json:"helmTemplateFile,omitempty"`       // chart-relative path of the source template (e.g. "templates/deployment.yaml")
+	HelmValuesPaths        []string   `json:"helmValuesPaths,omitempty"`        // dotted .Values.* keys (e.g. ["image.tag","replicaCount"]) statically traced from the rendered resource back to values.yaml; empty when provenance could not be determined
+	HelmTemplateLine       int        `json:"helmTemplateLine,omitempty"`       // 1-based line in the source template that produced this resource; 0 when unknown
 	KustomizeDirectoryName string     `json:"kustomizeDirectoryName,omitempty"` //Kustomize Directory name if File is from Kustomize Directory
 	LastCommit             LastCommit `json:"lastCommit,omitempty"`
 }


### PR DESCRIPTION
  Adds three optional fields to reporthandling.Source so downstream consumers can trace a rendered Helm resource
  back to its chart template and values.yaml keys: HelmTemplateFile (chart-relative template path, e.g.
  templates/deployment.yaml), HelmValuesPaths (the dotted .Values.* keys statically traced from the rendered
  resource, e.g. ["image.tag","replicaCount"]), and HelmTemplateLine (1-based line in the source template, 0 when
  unknown). All three are omitempty and purely additive - existing producers and JSON consumers are unaffected.

  Why kubescape needs this: issue kubescape/kubescape#1772 - kubescape fix currently can't produce correct fixes
  for Helm charts because Helm's render step drops all backward links from output YAML to the input template +
  values key. Earlier attempts (#1215, #1551, #1620, #1628) tried to recover line mapping post-hoc via yqlib and
  were unreliable enough that the mapping code was removed in #1995; today Helm-sourced findings either get skipped
   or get yq patches applied at rendered-output line numbers against template files, which don't land where users
  expect. The follow-up kubescape PR adds a helmprovenance package that walks each chart's templates (resolving
  _helpers.tpl includes with a cycle guard) and statically extracts the .Values.* references - both .Values.foo.bar
   and (index .Values "foo" "bar") forms - feeding them into these new Source fields during
  LoadResourcesFromHelmCharts. The fix handler then routes Helm-sourced resources away from the yq pipeline and
  prints actionable guidance pointing users at the specific values.yaml keys to edit, instead of silently skipping
  them or corrupting templates. Keeping the schema change here, isolated and additive, lets the kubescape side land
   cleanly once an opa-utils tag is cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new optional provenance fields to capture detailed Helm template metadata, including template file paths, statically traced configuration value references, and precise source line numbers. These enhancements provide improved debugging capabilities and better traceability for understanding the origin and composition of template-based deployments and configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/opa-utils/pull/168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->