### PR TITLE
feat(exceptions): support container-level exceptions via containerName attribute

### DIFF
--- a/exceptions/comparator.go
+++ b/exceptions/comparator.go
@@ -104,7 +104,20 @@ func (c *comparator) compareCluster(designatorCluster, clusterName string) bool 
 	return designatorCluster != "" && c.regexCompare(designatorCluster, clusterName)
 }
 
-func (c *comparator) compareContainerName(workload workloadinterface.IMetadata, containerName string) bool {
+// compareContainerName reports whether containerName matches any of the
+// failing containers. If failingNames is provided, only those containers are
+// checked; otherwise every container and init-container in the workload is
+// inspected (used by callers that have no FailedPaths context).
+func (c *comparator) compareContainerName(workload workloadinterface.IMetadata, containerName string, failingNames []string) bool {
+	if len(failingNames) > 0 {
+		for _, name := range failingNames {
+			if c.regexCompare(containerName, name) {
+				return true
+			}
+		}
+		return false
+	}
+
 	wl := workloadinterface.NewWorkloadObj(workload.GetObject())
 
 	if containers, err := wl.GetContainers(); err == nil {

--- a/exceptions/comparator.go
+++ b/exceptions/comparator.go
@@ -104,6 +104,28 @@ func (c *comparator) compareCluster(designatorCluster, clusterName string) bool 
 	return designatorCluster != "" && c.regexCompare(designatorCluster, clusterName)
 }
 
+func (c *comparator) compareContainerName(workload workloadinterface.IMetadata, containerName string) bool {
+	wl := workloadinterface.NewWorkloadObj(workload.GetObject())
+
+	if containers, err := wl.GetContainers(); err == nil {
+		for i := range containers {
+			if c.regexCompare(containerName, containers[i].Name) {
+				return true
+			}
+		}
+	}
+
+	if initContainers, err := wl.GetInitContainers(); err == nil {
+		for i := range initContainers {
+			if c.regexCompare(containerName, initContainers[i].Name) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // regexpCompareI performs a case-insensitive regexp match
 func (c *comparator) regexCompareI(reg, name string) bool {
 	var (

--- a/exceptions/comparator_test.go
+++ b/exceptions/comparator_test.go
@@ -319,9 +319,23 @@ func TestComparator_compareContainerName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, c.compareContainerName(tt.workload, tt.containerName))
+			// nil failingNames → full workload scan (backward-compat path)
+			assert.Equal(t, tt.expected, c.compareContainerName(tt.workload, tt.containerName, nil))
 		})
 	}
+}
+
+func TestComparator_compareContainerName_failingNamesFilter(t *testing.T) {
+	c := &comparator{}
+	wl := workloadinterface.NewWorkloadObj(podObject([]string{"app", "sidecar"}, nil))
+
+	// When failingNames is ["app"], only "app" is a valid match.
+	assert.True(t, c.compareContainerName(wl, "app", []string{"app"}))
+	assert.False(t, c.compareContainerName(wl, "sidecar", []string{"app"}))
+
+	// When failingNames is ["sidecar"], only "sidecar" is a valid match.
+	assert.True(t, c.compareContainerName(wl, "sidecar", []string{"sidecar"}))
+	assert.False(t, c.compareContainerName(wl, "app", []string{"sidecar"}))
 }
 
 func TestIsTypeWorkload(t *testing.T) {

--- a/exceptions/comparator_test.go
+++ b/exceptions/comparator_test.go
@@ -256,6 +256,74 @@ func TestComparator_comparePath(t *testing.T) {
 	}
 }
 
+func podObject(containers, initContainers []string) map[string]interface{} {
+	cs := make([]interface{}, len(containers))
+	for i, name := range containers {
+		cs[i] = map[string]interface{}{"name": name}
+	}
+	ics := make([]interface{}, len(initContainers))
+	for i, name := range initContainers {
+		ics[i] = map[string]interface{}{"name": name}
+	}
+	return map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "test-pod", "namespace": "default"},
+		"spec": map[string]interface{}{
+			"containers":     cs,
+			"initContainers": ics,
+		},
+	}
+}
+
+func TestComparator_compareContainerName(t *testing.T) {
+	c := &comparator{}
+
+	tests := []struct {
+		name          string
+		workload      workloadinterface.IMetadata
+		containerName string
+		expected      bool
+	}{
+		{
+			name:          "exact match on regular container",
+			workload:      workloadinterface.NewWorkloadObj(podObject([]string{"app", "sidecar"}, nil)),
+			containerName: "app",
+			expected:      true,
+		},
+		{
+			name:          "exact match on init container",
+			workload:      workloadinterface.NewWorkloadObj(podObject([]string{"app"}, []string{"init-setup"})),
+			containerName: "init-setup",
+			expected:      true,
+		},
+		{
+			name:          "regex wildcard matches container",
+			workload:      workloadinterface.NewWorkloadObj(podObject([]string{"proxy-envoy"}, nil)),
+			containerName: "proxy-.*",
+			expected:      true,
+		},
+		{
+			name:          "no container name match",
+			workload:      workloadinterface.NewWorkloadObj(podObject([]string{"app"}, nil)),
+			containerName: "other",
+			expected:      false,
+		},
+		{
+			name:          "no containers at all",
+			workload:      workloadinterface.NewWorkloadObj(podObject(nil, nil)),
+			containerName: "app",
+			expected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, c.compareContainerName(tt.workload, tt.containerName))
+		})
+	}
+}
+
 func TestIsTypeWorkload(t *testing.T) {
 	tests := []struct {
 		workload workloadinterface.IMetadata

--- a/exceptions/exceptionprocessor.go
+++ b/exceptions/exceptionprocessor.go
@@ -229,11 +229,33 @@ func (p *Processor) metadataHasException(workload workloadinterface.IMetadata, a
 		return false // paths do not match
 	}
 
-	if isTypeWorkload(workload) && len(attributes.GetLabels()) > 0 {
-		if !p.compareLabels(workload, attributes.GetLabels()) && !p.compareAnnotations(workload, attributes.GetLabels()) {
-			return false // labels nor annotations do not match
+	if isTypeWorkload(workload) {
+		allLabels := attributes.GetLabels()
+		containerName, hasContainerName := allLabels[identifiers.AttributeContainerName]
+
+		// Build a label map with containerName stripped out so it is not
+		// treated as a Kubernetes label during label/annotation comparison.
+		labelsWithoutContainer := allLabels
+		if hasContainerName {
+			labelsWithoutContainer = make(map[string]string, len(allLabels)-1)
+			for k, v := range allLabels {
+				if k != identifiers.AttributeContainerName {
+					labelsWithoutContainer[k] = v
+				}
+			}
+		}
+
+		if len(labelsWithoutContainer) > 0 {
+			if !p.compareLabels(workload, labelsWithoutContainer) && !p.compareAnnotations(workload, labelsWithoutContainer) {
+				return false // labels nor annotations do not match
+			}
+		}
+
+		if hasContainerName && !p.compareContainerName(workload, containerName) {
+			return false // container name does not match
 		}
 	}
+
 	return true
 }
 

--- a/exceptions/exceptionprocessor.go
+++ b/exceptions/exceptionprocessor.go
@@ -297,9 +297,31 @@ func (p *Processor) iterateRegoResponseVector(workload workloadinterface.IMetada
 // FailedPaths contain no container indices (e.g. pod-level findings) the
 // returned slice is nil and compareContainerName falls back to checking all
 // containers in the workload.
+//
+// For RegoResponseVector objects the vector itself carries no containers; the
+// containers live in the related objects. We recurse into each related workload
+// so that container-index resolution still works for vector-based findings.
 func extractFailingContainerNames(paths []string, workload workloadinterface.IMetadata) []string {
 	if len(paths) == 0 {
 		return nil
+	}
+
+	if isTypeRegoResponseVector(workload) {
+		v := objectsenvelopes.NewRegoResponseVectorObject(workload.GetObject())
+		seen := make(map[string]struct{})
+		for _, r := range v.GetRelatedObjects() {
+			for _, name := range extractFailingContainerNames(paths, r) {
+				seen[name] = struct{}{}
+			}
+		}
+		if len(seen) == 0 {
+			return nil
+		}
+		names := make([]string, 0, len(seen))
+		for name := range seen {
+			names = append(names, name)
+		}
+		return names
 	}
 
 	wl := workloadinterface.NewWorkloadObj(workload.GetObject())

--- a/exceptions/exceptionprocessor.go
+++ b/exceptions/exceptionprocessor.go
@@ -1,6 +1,8 @@
 package exceptions
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/armosec/armoapi-go/identifiers"
@@ -11,6 +13,10 @@ import (
 
 	"github.com/armosec/armoapi-go/armotypes"
 )
+
+// rexContainerPath matches "containers[N]" and "initContainers[N]" in a
+// FailedPath so we can resolve the container index to a name.
+var rexContainerPath = regexp.MustCompile(`(initC|c)ontainers\[(\d+)\]`)
 
 // Processor processes exceptions.
 type Processor struct {
@@ -59,7 +65,11 @@ func (p *Processor) SetRuleResponsExceptions(results []reporthandling.RuleRespon
 		}
 
 		for w := range workloads {
-			if exceptions := p.GetResourceExceptions(ruleExceptions, workloads[w], clusterName); len(exceptions) > 0 {
+			// Resolve which containers actually produced the finding so that a
+			// containerName exception is only applied when the excepted container
+			// is the one that failed, not just any container in the pod.
+			failingContainerNames := extractFailingContainerNames(results[i].FailedPaths, workloads[w])
+			if exceptions := p.getResourceExceptions(ruleExceptions, workloads[w], clusterName, failingContainerNames); len(exceptions) > 0 {
 				results[i].Exception = &exceptions[0]
 			}
 		}
@@ -135,15 +145,21 @@ func alertObjectToWorkloads(obj *reporthandling.AlertObject) []workloadinterface
 	return resources[:len(resources):len(resources)]
 }
 
-// GetResourceException get exceptions of single resource
+// GetResourceExceptions returns the exception policies that match workload.
+// It checks container membership across the whole workload; use
+// SetRuleResponsExceptions when FailedPaths are available for precise matching.
 func (p *Processor) GetResourceExceptions(ruleExceptions []armotypes.PostureExceptionPolicy, workload workloadinterface.IMetadata, clusterName string) []armotypes.PostureExceptionPolicy {
+	return p.getResourceExceptions(ruleExceptions, workload, clusterName, nil)
+}
+
+func (p *Processor) getResourceExceptions(ruleExceptions []armotypes.PostureExceptionPolicy, workload workloadinterface.IMetadata, clusterName string, failingContainerNames []string) []armotypes.PostureExceptionPolicy {
 	// no pre-allocation since most of the time it's empty or has only one element
 	var postureExceptionPolicy []armotypes.PostureExceptionPolicy
 
 	for _, ruleException := range ruleExceptions {
 		for _, resourceToPin := range ruleException.Resources {
 			resource := resourceToPin
-			if p.hasException(clusterName, &resource, workload) {
+			if p.hasException(clusterName, &resource, workload, failingContainerNames) {
 				postureExceptionPolicy = append(postureExceptionPolicy, ruleException)
 			}
 		}
@@ -185,8 +201,7 @@ func (p *Processor) matchesCluster(attributes identifiers.AttributesDesignators,
 	return p.compareCluster(cluster, clusterName)
 }
 
-// compareMetadata - compare namespace and kind
-func (p *Processor) hasException(clusterName string, designator *identifiers.PortalDesignator, workload workloadinterface.IMetadata) bool {
+func (p *Processor) hasException(clusterName string, designator *identifiers.PortalDesignator, workload workloadinterface.IMetadata, failingContainerNames []string) bool {
 	attributes := p.getAttributes(designator)
 
 	if attributes.GetCluster() == "" && attributes.GetNamespace() == "" && attributes.GetKind() == "" && attributes.GetName() == "" && attributes.GetResourceID() == "" && attributes.GetPath() == "" && len(attributes.GetLabels()) == 0 {
@@ -198,16 +213,23 @@ func (p *Processor) hasException(clusterName string, designator *identifiers.Por
 	}
 
 	if isTypeRegoResponseVector(workload) {
-		if p.iterateRegoResponseVector(workload, attributes) {
+		if p.iterateRegoResponseVector(workload, attributes, failingContainerNames) {
 			return true
+		}
+		// If containerName is in the designator, stop here: the base
+		// RegoResponseVector object is not a workload, so container membership
+		// cannot be verified on it. Falling through would silently skip the
+		// container check and produce false positives.
+		if _, ok := attributes.GetLabels()[identifiers.AttributeContainerName]; ok {
+			return false
 		}
 		// otherwise, continue to check the base object
 	}
-	return p.metadataHasException(workload, attributes)
+	return p.metadataHasException(workload, attributes, failingContainerNames)
 
 }
 
-func (p *Processor) metadataHasException(workload workloadinterface.IMetadata, attributes identifiers.AttributesDesignators) bool {
+func (p *Processor) metadataHasException(workload workloadinterface.IMetadata, attributes identifiers.AttributesDesignators, failingContainerNames []string) bool {
 
 	if attributes.GetNamespace() != "" && !p.compareNamespace(workload, attributes.GetNamespace()) {
 		return false // namespaces do not match
@@ -251,7 +273,7 @@ func (p *Processor) metadataHasException(workload workloadinterface.IMetadata, a
 			}
 		}
 
-		if hasContainerName && !p.compareContainerName(workload, containerName) {
+		if hasContainerName && !p.compareContainerName(workload, containerName, failingContainerNames) {
 			return false // container name does not match
 		}
 	}
@@ -259,12 +281,59 @@ func (p *Processor) metadataHasException(workload workloadinterface.IMetadata, a
 	return true
 }
 
-func (p *Processor) iterateRegoResponseVector(workload workloadinterface.IMetadata, attributes identifiers.AttributesDesignators) bool {
+func (p *Processor) iterateRegoResponseVector(workload workloadinterface.IMetadata, attributes identifiers.AttributesDesignators, failingContainerNames []string) bool {
 	v := objectsenvelopes.NewRegoResponseVectorObject(workload.GetObject())
 	for _, r := range v.GetRelatedObjects() {
-		if p.metadataHasException(r, attributes) {
+		if p.metadataHasException(r, attributes, failingContainerNames) {
 			return true
 		}
 	}
 	return false
+}
+
+// extractFailingContainerNames parses paths like "spec.containers[0].…" or
+// "spec.template.spec.initContainers[1].…" to find which containers produced
+// the finding, then returns their names from the workload spec. When the
+// FailedPaths contain no container indices (e.g. pod-level findings) the
+// returned slice is nil and compareContainerName falls back to checking all
+// containers in the workload.
+func extractFailingContainerNames(paths []string, workload workloadinterface.IMetadata) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	wl := workloadinterface.NewWorkloadObj(workload.GetObject())
+	containers, _ := wl.GetContainers()
+	initContainers, _ := wl.GetInitContainers()
+	if len(containers)+len(initContainers) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, path := range paths {
+		for _, m := range rexContainerPath.FindAllStringSubmatch(path, -1) {
+			idx, err := strconv.Atoi(m[2])
+			if err != nil {
+				continue
+			}
+			if m[1] == "initC" {
+				if idx < len(initContainers) {
+					seen[initContainers[idx].Name] = struct{}{}
+				}
+			} else {
+				if idx < len(containers) {
+					seen[containers[idx].Name] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	return names
 }

--- a/exceptions/exceptionprocessor_test.go
+++ b/exceptions/exceptionprocessor_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
+	"github.com/kubescape/opa-utils/reporthandling"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -952,7 +953,7 @@ func TestHasException(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, processor.hasException(tt.clusterName, tt.designator, tt.workload))
+			assert.Equal(t, tt.expected, processor.hasException(tt.clusterName, tt.designator, tt.workload, nil))
 		})
 	}
 }
@@ -1204,7 +1205,7 @@ func TestProcessor_iterateRegoResponseVector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, p.iterateRegoResponseVector(tt.workload, tt.designator.DigestPortalDesignator()))
+			assert.Equal(t, tt.expected, p.iterateRegoResponseVector(tt.workload, tt.designator.DigestPortalDesignator(), nil))
 		})
 	}
 }
@@ -1278,7 +1279,104 @@ func TestMetadataHasException_ContainerName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			attrs := tt.designator.DigestPortalDesignator()
-			assert.Equal(t, tt.expected, p.metadataHasException(pod, attrs))
+			assert.Equal(t, tt.expected, p.metadataHasException(pod, attrs, nil))
 		})
 	}
+}
+
+func TestSetRuleResponsExceptions_ContainerNamePrecision(t *testing.T) {
+	p := NewProcessor()
+
+	// Pod has two containers: app (index 0) and sidecar (index 1).
+	podObj := podObject([]string{"app", "sidecar"}, nil)
+	exception := armotypes.PostureExceptionPolicy{
+		Resources: []identifiers.PortalDesignator{
+			{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeContainerName: "sidecar"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		failedPaths []string
+		wantExcept  bool
+	}{
+		{
+			name:        "finding on sidecar (containers[1]) — exception matches",
+			failedPaths: []string{"spec.containers[1].securityContext.privileged"},
+			wantExcept:  true,
+		},
+		{
+			name:        "finding on app (containers[0]) — exception must NOT apply",
+			failedPaths: []string{"spec.containers[0].securityContext.privileged"},
+			wantExcept:  false,
+		},
+		{
+			name:        "no failed paths — falls back to workload scan, sidecar found",
+			failedPaths: nil,
+			wantExcept:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := reporthandling.RuleResponse{
+				AlertObject: reporthandling.AlertObject{
+					K8SApiObjects: []map[string]interface{}{podObj},
+				},
+				AssistedRemediation: reporthandling.AssistedRemediation{
+					FailedPaths: tt.failedPaths,
+				},
+			}
+			results := []reporthandling.RuleResponse{result}
+			p.SetRuleResponsExceptions(results, []armotypes.PostureExceptionPolicy{exception}, "")
+			if tt.wantExcept {
+				assert.NotNil(t, results[0].Exception, "expected exception to be set")
+			} else {
+				assert.Nil(t, results[0].Exception, "expected exception NOT to be set")
+			}
+		})
+	}
+}
+
+func TestHasException_RegoResponseVector_ContainerNameFallbackBlocked(t *testing.T) {
+	p := NewProcessor()
+
+	// A RegoResponseVector whose base name is "base-subject".
+	// The related object has containers [app], none named "missing".
+	vector := objectsenvelopes.NewRegoResponseVectorObject(map[string]interface{}{
+		"kind": "RegoResponseVector",
+		"metadata": map[string]interface{}{
+			"name": "base-subject",
+		},
+		"relatedObjects": []interface{}{
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata":   map[string]interface{}{"name": "base-subject"},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{"name": "app"},
+					},
+				},
+			},
+		},
+	})
+
+	designator := &identifiers.PortalDesignator{
+		DesignatorType: identifiers.DesignatorAttributes,
+		Attributes: map[string]string{
+			identifiers.AttributeName:          "base-subject",
+			identifiers.AttributeContainerName: "missing",
+		},
+	}
+
+	attrs := designator.DigestPortalDesignator()
+	// The base vector's name matches, but "missing" is not a container —
+	// hasException must return false, not bypass the container check.
+	result := p.hasException("", designator, vector, nil)
+	_ = attrs
+	assert.False(t, result, "containerName on a RegoResponseVector must not fall back to base-object name match")
 }

--- a/exceptions/exceptionprocessor_test.go
+++ b/exceptions/exceptionprocessor_test.go
@@ -1341,6 +1341,75 @@ func TestSetRuleResponsExceptions_ContainerNamePrecision(t *testing.T) {
 	}
 }
 
+func TestSetRuleResponsExceptions_RegoResponseVector_ContainerNamePrecision(t *testing.T) {
+	p := NewProcessor()
+
+	// A RegoResponseVector wrapping a pod that has containers [app (index 0), sidecar (index 1)].
+	// The exception targets "sidecar". The FailedPaths point to containers[0] = "app".
+	// The exception must NOT be applied because the failing container is "app", not "sidecar".
+	//
+	// Note: IsTypeRegoResponseVector requires top-level "kind", "name", and "relatedObjects"
+	// keys — not the nested metadata.name used by regular Kubernetes objects.
+	podObj := podObject([]string{"app", "sidecar"}, nil)
+	vector := objectsenvelopes.NewRegoResponseVectorObject(map[string]interface{}{
+		"kind":           "RegoResponseVector",
+		"name":           "vec",
+		"relatedObjects": []interface{}{podObj},
+	})
+	vectorRaw := vector.GetObject()
+
+	exception := armotypes.PostureExceptionPolicy{
+		Resources: []identifiers.PortalDesignator{
+			{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeContainerName: "sidecar"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		failedPaths []string
+		wantExcept  bool
+	}{
+		{
+			name:        "vector finding on app (containers[0]) — sidecar exception must NOT apply",
+			failedPaths: []string{"spec.containers[0].securityContext.privileged"},
+			wantExcept:  false,
+		},
+		{
+			name:        "vector finding on sidecar (containers[1]) — sidecar exception must apply",
+			failedPaths: []string{"spec.containers[1].securityContext.privileged"},
+			wantExcept:  true,
+		},
+		{
+			name:        "no failed paths — falls back to full scan, sidecar found",
+			failedPaths: nil,
+			wantExcept:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := reporthandling.RuleResponse{
+				AlertObject: reporthandling.AlertObject{
+					K8SApiObjects: []map[string]interface{}{vectorRaw},
+				},
+				AssistedRemediation: reporthandling.AssistedRemediation{
+					FailedPaths: tt.failedPaths,
+				},
+			}
+			results := []reporthandling.RuleResponse{result}
+			p.SetRuleResponsExceptions(results, []armotypes.PostureExceptionPolicy{exception}, "")
+			if tt.wantExcept {
+				assert.NotNil(t, results[0].Exception, "expected exception to be set")
+			} else {
+				assert.Nil(t, results[0].Exception, "expected exception NOT to be set")
+			}
+		})
+	}
+}
+
 func TestHasException_RegoResponseVector_ContainerNameFallbackBlocked(t *testing.T) {
 	p := NewProcessor()
 
@@ -1348,9 +1417,7 @@ func TestHasException_RegoResponseVector_ContainerNameFallbackBlocked(t *testing
 	// The related object has containers [app], none named "missing".
 	vector := objectsenvelopes.NewRegoResponseVectorObject(map[string]interface{}{
 		"kind": "RegoResponseVector",
-		"metadata": map[string]interface{}{
-			"name": "base-subject",
-		},
+		"name": "base-subject",
 		"relatedObjects": []interface{}{
 			map[string]interface{}{
 				"apiVersion": "v1",

--- a/exceptions/exceptionprocessor_test.go
+++ b/exceptions/exceptionprocessor_test.go
@@ -1410,6 +1410,67 @@ func TestSetRuleResponsExceptions_RegoResponseVector_ContainerNamePrecision(t *t
 	}
 }
 
+func TestSetRuleResponsExceptions_ExternalObjects_RegoResponseVector(t *testing.T) {
+	p := NewProcessor()
+
+	// Same scenario as the K8SApiObjects test but delivered via AlertObject.ExternalObjects
+	// (a single map[string]interface{}, not a list).
+	// The vector wraps a pod with containers [app (0), sidecar (1)].
+	// Exception targets "sidecar"; FailedPaths point at containers[0] = "app".
+	podObj := podObject([]string{"app", "sidecar"}, nil)
+	vectorRaw := map[string]interface{}{
+		"kind":           "RegoResponseVector",
+		"name":           "vec",
+		"relatedObjects": []interface{}{podObj},
+	}
+
+	exception := armotypes.PostureExceptionPolicy{
+		Resources: []identifiers.PortalDesignator{
+			{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeContainerName: "sidecar"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		failedPaths []string
+		wantExcept  bool
+	}{
+		{
+			name:        "ExternalObjects vector: finding on app — sidecar exception must NOT apply",
+			failedPaths: []string{"spec.containers[0].securityContext.privileged"},
+			wantExcept:  false,
+		},
+		{
+			name:        "ExternalObjects vector: finding on sidecar — exception must apply",
+			failedPaths: []string{"spec.containers[1].securityContext.privileged"},
+			wantExcept:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := reporthandling.RuleResponse{
+				AlertObject: reporthandling.AlertObject{
+					ExternalObjects: vectorRaw,
+				},
+				AssistedRemediation: reporthandling.AssistedRemediation{
+					FailedPaths: tt.failedPaths,
+				},
+			}
+			results := []reporthandling.RuleResponse{result}
+			p.SetRuleResponsExceptions(results, []armotypes.PostureExceptionPolicy{exception}, "")
+			if tt.wantExcept {
+				assert.NotNil(t, results[0].Exception, "expected exception to be set")
+			} else {
+				assert.Nil(t, results[0].Exception, "expected exception NOT to be set")
+			}
+		})
+	}
+}
+
 func TestHasException_RegoResponseVector_ContainerNameFallbackBlocked(t *testing.T) {
 	p := NewProcessor()
 

--- a/exceptions/exceptionprocessor_test.go
+++ b/exceptions/exceptionprocessor_test.go
@@ -1208,3 +1208,77 @@ func TestProcessor_iterateRegoResponseVector(t *testing.T) {
 		})
 	}
 }
+
+func TestMetadataHasException_ContainerName(t *testing.T) {
+	p := NewProcessor()
+
+	pod := workloadinterface.NewWorkloadObj(podObject([]string{"app", "sidecar"}, []string{"init-setup"}))
+
+	tests := []struct {
+		name       string
+		designator *identifiers.PortalDesignator
+		expected   bool
+	}{
+		{
+			name: "exception targets matching container",
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeContainerName: "sidecar"},
+			},
+			expected: true,
+		},
+		{
+			name: "exception targets non-existing container",
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeContainerName: "other"},
+			},
+			expected: false,
+		},
+		{
+			name: "exception targets init container",
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeContainerName: "init-setup"},
+			},
+			expected: true,
+		},
+		{
+			name: "containerName with regex wildcard",
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes:     map[string]string{identifiers.AttributeContainerName: "side.*"},
+			},
+			expected: true,
+		},
+		{
+			name: "containerName combined with matching namespace",
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes: map[string]string{
+					identifiers.AttributeNamespace:     "default",
+					identifiers.AttributeContainerName: "app",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "containerName combined with non-matching namespace",
+			designator: &identifiers.PortalDesignator{
+				DesignatorType: identifiers.DesignatorAttributes,
+				Attributes: map[string]string{
+					identifiers.AttributeNamespace:     "other-ns",
+					identifiers.AttributeContainerName: "app",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := tt.designator.DigestPortalDesignator()
+			assert.Equal(t, tt.expected, p.metadataHasException(pod, attrs))
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Exceptions in Kubescape currently work at the pod/workload level. If a pod has multiple containers and only one of them needs to be excluded from a check, there's no way to do that.

The `containerName` attribute key already exists in `armoapi-go` (`identifiers.AttributeContainerName`), but it was falling into the `labels` bucket in `DigestAttributesDesignator` and being compared against pod labels — which always fails.

This PR wires it up properly.

**What changed:**

- `exceptions/comparator.go` — added `compareContainerName` that checks all containers and init containers in a workload using regex (same as namespace/name/kind matching)
- `exceptions/exceptionprocessor.go` — `metadataHasException` now strips `containerName` from the labels map before label comparison and runs `compareContainerName` separately

**Example exception that now works:**

```json
{
  "designators": [{
    "designatorType": "Attributes",
    "attributes": {
      "namespace": "kube-system",
      "name":      "kube-proxy",
      "containerName": "kube-proxy"
    }
  }]
}
```

## Related issues/PRs

Closes kubescape/kubescape#1684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exception rules support matching by container name (regular & init), including regex/wildcards, combined with other attributes like namespace.

* **Improvements**
  * Exception evaluation now determines which container(s) actually failed and applies exceptions precisely; container-scoped checks no longer fall back incorrectly.
  * Container-name filtering option enables restricting matches to an explicit list when provided.

* **Tests**
  * Added comprehensive tests validating container-name matching, filtering behavior, and precision with response vectors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/opa-utils/pull/169)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->