### PR TITLE
poc: add CELLanguage constant to RuleLanguages

### DIFF
--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -14,6 +14,7 @@ type RuleLanguages string
 const (
 	RegoLanguage  RuleLanguages = "Rego"
 	RegoLanguage2 RuleLanguages = "rego"
+	CELLanguage   RuleLanguages = "CEL"
 )
 
 // RuleMatchObjects defines which objects this rule applied on

--- a/reporthandling/datastructures_test.go
+++ b/reporthandling/datastructures_test.go
@@ -61,6 +61,17 @@ func TestPostureReportWithExternalResource(t *testing.T) {
 
 	assert.Equal(t, expectedID, report2.Resources[0].GetID())
 }
+func TestRuleLanguagesConstants(t *testing.T) {
+	assert.Equal(t, RuleLanguages("Rego"), RegoLanguage)
+	assert.Equal(t, RuleLanguages("rego"), RegoLanguage2)
+	assert.Equal(t, RuleLanguages("CEL"), CELLanguage)
+}
+
+func TestCELLanguageIsDistinct(t *testing.T) {
+	assert.NotEqual(t, CELLanguage, RegoLanguage)
+	assert.NotEqual(t, CELLanguage, RegoLanguage2)
+}
+
 func TestMockFrameworkA(t *testing.T) {
 	policy := MockFrameworkA()
 	bp, err := json.Marshal(policy)


### PR DESCRIPTION
so this is a small poc for the CEL engine project I'm working on as part of the LFX mentorship.

the change itself is pretty simple. I just added a new constant `CELLanguage = "CEL"` to the `RuleLanguages` type in `reporthandling/datastructures.go`. right now only `RegoLanguage` and `RegoLanguage2` exist there, and the dispatcher in kubescape's opaprocessor uses this type to decide which evaluator to run. so before we can even think about writing a CEL evaluator, this constant needs to exist.

I also added two tests to make sure the value is correct and that it doesn't accidentally match either of the Rego constants. nothing fancy, just making sure the basics are solid.

this is not production ready at all, just laying the foundation. the actual wiring into the dispatcher and building out the evaluator comes later.