### PR TITLE
fix(score): use related object in RegoResponseVector scoring loop

### DIFF
--- a/score/score.go
+++ b/score/score.go
@@ -144,12 +144,13 @@ func (su *ScoreUtil) GetScore(v map[string]interface{}) float32 {
 		score := defaultScore
 
 		for i := range related {
-			if !k8sinterface.IsTypeWorkload(related[i].GetObject()) {
+			obj := related[i].GetObject()
+			if !k8sinterface.IsTypeWorkload(obj) {
 				continue
 			}
 
-			wl := workloadinterface.NewWorkloadObj(v)
-			score = max32(score, su.processWorkload(wl, score, v))
+			wl := workloadinterface.NewWorkloadObj(obj)
+			score = max32(score, su.processWorkload(wl, defaultScore, obj))
 		}
 
 		return score


### PR DESCRIPTION
So I was going through the score/score.go file in the opa-utils codebase and found a bug in the GetScore function. Basically, when a finding comes in as a RegoResponseVector (which is how a lot of Kubescape rules report results when multiple K8s resources are involved), the code loops over the related objects but never actually uses them. It was building the workload from the outer vector map v every single time, not from related[i]. So no matter how many replicas a Deployment had, or how many nodes a DaemonSet was running on, the score came out the same flat value. The replica multiplier and the DaemonSet node count logic were just... never firing for these findings.

I fixed it by making the loop actually use related[i].GetObject() to build the workload, and seeding processWorkload with defaultScore instead of the running accumulator. Small change, three lines basically, but now the scoring actually reflects the real blast radius of a finding instead of just returning 1.0 every time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where scoring calculations could be incorrect when processing multiple related objects. Scoring now correctly evaluates each object individually before determining the final result.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/opa-utils/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->