### PR TITLE
feat(reportsummary): add VAPEnforcementStatus to ControlSummary

### DIFF
--- a/reporthandling/results/v1/reportsummary/datastructures.go
+++ b/reporthandling/results/v1/reportsummary/datastructures.go
@@ -37,6 +37,14 @@ type FrameworkSummary struct {
 	ComplianceScore float32             `json:"complianceScore"`
 }
 
+// VAPEnforcementStatus holds the enforcement state of a control via a
+// ValidatingAdmissionPolicy deployed in the cluster.
+type VAPEnforcementStatus struct {
+	PolicyName string   `json:"policyName"`
+	Bound      bool     `json:"bound"`
+	Actions    []string `json:"actions,omitempty"`
+}
+
 // ControlSummary summary of scanning from a single control perspective
 type ControlSummary struct {
 	StatusInfo        apis.StatusInfo          `json:"statusInfo,omitempty"`
@@ -52,6 +60,7 @@ type ControlSummary struct {
 	ComplianceScore   *float32                 `json:"complianceScore,omitempty"`
 	ScoreFactor       float32                  `json:"scoreFactor"`
 	Category          *reporthandling.Category `json:"category,omitempty"`
+	VAPEnforcement    *VAPEnforcementStatus    `json:"vapEnforcement,omitempty"`
 }
 
 type StatusCounters struct {


### PR DESCRIPTION
This is the first part of the work tracked in kubescape/kubescape#2299.

The full feature is about surfacing VAP enforcement status in kubescape scan results when scanning a live cluster. right now if you deploy cel-admission-library VAPs and create bindings for them, kubescape scan has no idea they exist. it just shows pass/fail with no info about whether that control is being enforced at admission time or not.

to fix that in kubescape, the scan result types need to carry that enforcement info first. that's what this PR does.

I added a new struct VAPEnforcementStatus with three fields: the policy name, whether a binding exists for it, and what actions that binding is set to (Deny, Warn, or Audit). then I added it as an optional pointer field on ControlSummary with omitempty, so nothing breaks for existing consumers and serialized reports stay the same if the field isn't set.

what comes next in kubescape/kubescape:
- collect ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
  resources from the live cluster during scan
- build a controlId to enforcement index using the controlId label that
  cel-admission-library stamps on every VAP
- populate VAPEnforcementStatus on each ControlSummary after the scan
  completes
- show the enforcement status in scan output