### PR TITLE
reporthandling/v2: support encryption metadata in report schema

### DIFF
--- a/reporthandling/v2/datastructures.go
+++ b/reporthandling/v2/datastructures.go
@@ -79,9 +79,16 @@ type ContextMetadata struct {
 }
 
 type Metadata struct {
-	ContextMetadata ContextMetadata `json:"targetMetadata,omitempty"`
-	ClusterMetadata ClusterMetadata `json:"clusterMetadata,omitempty"`
-	ScanMetadata    ScanMetadata    `json:"scanMetadata,omitempty"`
+	ContextMetadata    ContextMetadata     `json:"targetMetadata,omitempty"`
+	ClusterMetadata    ClusterMetadata     `json:"clusterMetadata,omitempty"`
+	ScanMetadata       ScanMetadata        `json:"scanMetadata,omitempty"`
+	EncryptionMetadata *EncryptionMetadata `json:"encryptionMetadata,omitempty"`
+}
+
+type EncryptionMetadata struct {
+	Version      string `json:"version,omitempty"`
+	Algorithm    string `json:"algorithm,omitempty"`
+	EncryptedDEK string `json:"encryptedDEK,omitempty"`
 }
 
 type ScanningTarget uint16

--- a/reporthandling/v2/datastructures.go
+++ b/reporthandling/v2/datastructures.go
@@ -87,7 +87,8 @@ type Metadata struct {
 
 type EncryptionMetadata struct {
 	Version      string `json:"version,omitempty"`
-	Algorithm    string `json:"algorithm,omitempty"`
+	DEKAlgorithm string `json:"dekAlgorithm,omitempty"`
+	KEKAlgorithm string `json:"kekAlgorithm,omitempty"`
 	EncryptedDEK string `json:"encryptedDEK,omitempty"`
 }
 

--- a/reporthandling/v2/datastructures_test.go
+++ b/reporthandling/v2/datastructures_test.go
@@ -108,6 +108,11 @@ func GetPostureReportMock() *PostureReport {
 				ControlsInputs:     "/path/to/ctrls",
 				VerboseMode:        true,
 			},
+			EncryptionMetadata: &EncryptionMetadata{
+				Version:      "v1",
+				Algorithm:    "AES256_GCM",
+				EncryptedDEK: "encrypted-dek-placeholder",
+			},
 		},
 	}
 }
@@ -149,4 +154,8 @@ func TestPostureReportGojayUnmarshal(t *testing.T) {
 	assert.Equal(t, original.Metadata.ScanMetadata.UseExceptions, postureReport.Metadata.ScanMetadata.UseExceptions)
 	assert.Equal(t, original.Metadata.ScanMetadata.ControlsInputs, postureReport.Metadata.ScanMetadata.ControlsInputs)
 	assert.Equal(t, original.Metadata.ScanMetadata.VerboseMode, postureReport.Metadata.ScanMetadata.VerboseMode)
+	assert.NotNil(t, postureReport.Metadata.EncryptionMetadata)
+	assert.Equal(t, original.Metadata.EncryptionMetadata.Version, postureReport.Metadata.EncryptionMetadata.Version)
+	assert.Equal(t, original.Metadata.EncryptionMetadata.Algorithm, postureReport.Metadata.EncryptionMetadata.Algorithm)
+	assert.Equal(t, original.Metadata.EncryptionMetadata.EncryptedDEK, postureReport.Metadata.EncryptionMetadata.EncryptedDEK)
 }

--- a/reporthandling/v2/datastructures_test.go
+++ b/reporthandling/v2/datastructures_test.go
@@ -162,14 +162,12 @@ func TestPostureReportGojayUnmarshal(t *testing.T) {
 	assert.Equal(t, original.Metadata.EncryptionMetadata.EncryptedDEK, postureReport.Metadata.EncryptionMetadata.EncryptedDEK)
 }
 
-func TestPostureReportGojayUnmarshal_InvalidEncryptionMetadata(t *testing.T) {
+func TestPostureReportGojayUnmarshal_NoEncryptionMetadata(
+	t *testing.T,
+) {
 	payload := []byte(`{
-		"metadata": {
-			"encryptionMetadata": {
-				"version": "v1"
-			}
-		}
-	}`)
+        "metadata": {}
+    }`)
 
 	report := &PostureReport{}
 
@@ -178,9 +176,5 @@ func TestPostureReportGojayUnmarshal_InvalidEncryptionMetadata(t *testing.T) {
 	).Decode(report)
 
 	assert.NoError(t, err)
-
-	assert.Nil(
-		t,
-		report.Metadata.EncryptionMetadata,
-	)
+	assert.Nil(t, report.Metadata.EncryptionMetadata)
 }

--- a/reporthandling/v2/datastructures_test.go
+++ b/reporthandling/v2/datastructures_test.go
@@ -159,3 +159,26 @@ func TestPostureReportGojayUnmarshal(t *testing.T) {
 	assert.Equal(t, original.Metadata.EncryptionMetadata.Algorithm, postureReport.Metadata.EncryptionMetadata.Algorithm)
 	assert.Equal(t, original.Metadata.EncryptionMetadata.EncryptedDEK, postureReport.Metadata.EncryptionMetadata.EncryptedDEK)
 }
+
+func TestPostureReportGojayUnmarshal_InvalidEncryptionMetadata(t *testing.T) {
+	payload := []byte(`{
+		"metadata": {
+			"encryptionMetadata": {
+				"version": "v1"
+			}
+		}
+	}`)
+
+	report := &PostureReport{}
+
+	err := gojay.NewDecoder(
+		bytes.NewReader(payload),
+	).Decode(report)
+
+	assert.NoError(t, err)
+
+	assert.Nil(
+		t,
+		report.Metadata.EncryptionMetadata,
+	)
+}

--- a/reporthandling/v2/datastructures_test.go
+++ b/reporthandling/v2/datastructures_test.go
@@ -110,7 +110,8 @@ func GetPostureReportMock() *PostureReport {
 			},
 			EncryptionMetadata: &EncryptionMetadata{
 				Version:      "v1",
-				Algorithm:    "AES256_GCM",
+				DEKAlgorithm: "AES256_GCM",
+				KEKAlgorithm: "AES256_GCM",
 				EncryptedDEK: "encrypted-dek-placeholder",
 			},
 		},
@@ -156,7 +157,8 @@ func TestPostureReportGojayUnmarshal(t *testing.T) {
 	assert.Equal(t, original.Metadata.ScanMetadata.VerboseMode, postureReport.Metadata.ScanMetadata.VerboseMode)
 	assert.NotNil(t, postureReport.Metadata.EncryptionMetadata)
 	assert.Equal(t, original.Metadata.EncryptionMetadata.Version, postureReport.Metadata.EncryptionMetadata.Version)
-	assert.Equal(t, original.Metadata.EncryptionMetadata.Algorithm, postureReport.Metadata.EncryptionMetadata.Algorithm)
+	assert.Equal(t, original.Metadata.EncryptionMetadata.DEKAlgorithm, postureReport.Metadata.EncryptionMetadata.DEKAlgorithm)
+	assert.Equal(t, original.Metadata.EncryptionMetadata.KEKAlgorithm, postureReport.Metadata.EncryptionMetadata.KEKAlgorithm)
 	assert.Equal(t, original.Metadata.EncryptionMetadata.EncryptedDEK, postureReport.Metadata.EncryptionMetadata.EncryptedDEK)
 }
 

--- a/reporthandling/v2/gojayunmarshaller.go
+++ b/reporthandling/v2/gojayunmarshaller.go
@@ -68,14 +68,16 @@ func (m *Metadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err erro
 
 	case "encryptionMetadata":
 		encryptionMetadata := &EncryptionMetadata{}
-		if err = dec.Object(encryptionMetadata); err == nil {
-			m.EncryptionMetadata = encryptionMetadata
-		}
 
+		if err = dec.Object(encryptionMetadata); err == nil {
+			if encryptionMetadata.Version != "" &&
+				encryptionMetadata.Algorithm != "" {
+				m.EncryptionMetadata = encryptionMetadata
+			}
+		}
 	}
 
 	return err
-
 }
 
 func (file *Metadata) NKeys() int {

--- a/reporthandling/v2/gojayunmarshaller.go
+++ b/reporthandling/v2/gojayunmarshaller.go
@@ -71,7 +71,8 @@ func (m *Metadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err erro
 
 		if err = dec.Object(encryptionMetadata); err == nil {
 			if encryptionMetadata.Version != "" &&
-				encryptionMetadata.Algorithm != "" {
+				encryptionMetadata.DEKAlgorithm != "" &&
+				encryptionMetadata.KEKAlgorithm != "" {
 				m.EncryptionMetadata = encryptionMetadata
 			}
 		}
@@ -200,8 +201,11 @@ func (e *EncryptionMetadata) UnmarshalJSONObject(
 	case "version":
 		err = dec.String(&(e.Version))
 
-	case "algorithm":
-		err = dec.String(&(e.Algorithm))
+	case "dekAlgorithm":
+		err = dec.String(&(e.DEKAlgorithm))
+
+	case "kekAlgorithm":
+		err = dec.String(&(e.KEKAlgorithm))
 
 	case "encryptedDEK":
 		err = dec.String(&(e.EncryptedDEK))

--- a/reporthandling/v2/gojayunmarshaller.go
+++ b/reporthandling/v2/gojayunmarshaller.go
@@ -70,12 +70,9 @@ func (m *Metadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err erro
 		encryptionMetadata := &EncryptionMetadata{}
 
 		if err = dec.Object(encryptionMetadata); err == nil {
-			if encryptionMetadata.Version != "" &&
-				encryptionMetadata.DEKAlgorithm != "" &&
-				encryptionMetadata.KEKAlgorithm != "" {
-				m.EncryptionMetadata = encryptionMetadata
-			}
+			m.EncryptionMetadata = encryptionMetadata
 		}
+
 	}
 
 	return err

--- a/reporthandling/v2/gojayunmarshaller.go
+++ b/reporthandling/v2/gojayunmarshaller.go
@@ -65,6 +65,13 @@ func (m *Metadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (err erro
 
 	case "targetMetadata":
 		err = dec.Object(&(m.ContextMetadata))
+
+	case "encryptionMetadata":
+		encryptionMetadata := &EncryptionMetadata{}
+		if err = dec.Object(encryptionMetadata); err == nil {
+			m.EncryptionMetadata = encryptionMetadata
+		}
+
 	}
 
 	return err
@@ -178,5 +185,29 @@ func (m *ClusterMetadata) UnmarshalJSONObject(dec *gojay.Decoder, key string) (e
 }
 
 func (file *ClusterMetadata) NKeys() int {
+	return 0
+}
+
+// UnmarshalJSONObject unmarshals incoming JSON data into an EncryptionMetadata object
+func (e *EncryptionMetadata) UnmarshalJSONObject(
+	dec *gojay.Decoder,
+	key string,
+) (err error) {
+
+	switch key {
+	case "version":
+		err = dec.String(&(e.Version))
+
+	case "algorithm":
+		err = dec.String(&(e.Algorithm))
+
+	case "encryptedDEK":
+		err = dec.String(&(e.EncryptedDEK))
+	}
+
+	return err
+}
+
+func (e *EncryptionMetadata) NKeys() int {
 	return 0
 }


### PR DESCRIPTION
Part of: #173

## Overview

Add report-level encryption metadata to the posture report schema.

This introduces a new optional `EncryptionMetadata` section under `Metadata` that can be used to describe encrypted report workflows and carry envelope-encryption information required for future decryption support.

### Changes

* Add `EncryptionMetadata` to `reporthandling/v2.Metadata`
* Add `EncryptionMetadata` struct containing:

  * `version`
  * `dekAlgorithm`
  * `kekAlgorithm`
  * `encryptedDEK`
* Extend GoJay unmarshalling support for `EncryptionMetadata`
* Add schema and unmarshalling tests covering the new metadata section
* Preserve backward compatibility for reports that do not contain encryption metadata

### Example

```json
{
  "metadata": {
    "encryptionMetadata": {
      "version": "v1",
      "dekAlgorithm": "AES256_GCM",
      "kekAlgorithm": "AES256_GCM",
      "encryptedDEK": "<encrypted-dek>"
    }
  }
}
```

Recent work introduced reversible encryption for repository context metadata using a Data Encryption Key (DEK). To support a complete encryption/decryption workflow, reports need a standard location to carry encryption-related metadata alongside encrypted payloads.

This change establishes that schema contract without changing existing report behavior. Reports that do not use encryption remain fully backward compatible.

### Future Work

This schema serves as the foundation for:

* DEK envelope-encryption workflows
* Key-encryption-key (KEK) based key management
* Report decryption tooling
* Additional encryption metadata fields as requirements evolve
* Expansion of reversible encryption beyond repository metadata




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now include optional encryption metadata containing encryption version, DEK algorithm, KEK algorithm, and encrypted DEK information.

* **Tests**
  * Added tests to verify encryption metadata serialization and deserialization in report handling, including validation of scenarios without encryption metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->