### PR TITLE
feat(reporthandling): add CELLanguage constant for CEL rule evaluation

### DIFF
--- a/reporthandling/datastructures.go
+++ b/reporthandling/datastructures.go
@@ -14,6 +14,7 @@ type RuleLanguages string
 const (
 	RegoLanguage  RuleLanguages = "Rego"
 	RegoLanguage2 RuleLanguages = "rego"
+	CELLanguage   RuleLanguages = "CEL"
 )
 
 // RuleMatchObjects defines which objects this rule applied on

--- a/reporthandling/datastructures_test.go
+++ b/reporthandling/datastructures_test.go
@@ -84,3 +84,20 @@ func TestMockPostureReportA(t *testing.T) {
 	}
 
 }
+
+func TestRuleLanguagesConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		language RuleLanguages
+		expected string
+	}{
+		{"Rego (capitalized)", RegoLanguage, "Rego"},
+		{"rego (lowercase)", RegoLanguage2, "rego"},
+		{"CEL", CELLanguage, "CEL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(tt.language))
+		})
+	}
+}


### PR DESCRIPTION
Adds `CELLanguage RuleLanguages = "CEL"`  alongside the existing Rego constants.

This is the first step for the CEL rule engine work in kubescape/kubescape#2001. Without this constant, kubescape has no way to label a rule as CEL, so the dispatch in `runOPAOnSingleRule` can't route to a CEL evaluator. The actual evaluator and dispatch wiring come in follow-up PRs on the kubescape side.
  
Also added a small table-driven test covering all three language constants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CEL (Common Expression Language) as a new rule language option, complementing existing Rego language variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->