### PR TITLE
fix(reporthandling): resolve roleRef within the binding's own namespace

### DIFF
--- a/reporthandling/regoresourcesaggregator.go
+++ b/reporthandling/regoresourcesaggregator.go
@@ -29,9 +29,10 @@ func RegoResourcesAggregator(rule *PolicyRule, k8sObjects []workloadinterface.IM
 	return k8sObjects, nil
 }
 
-// roleRefString returns roleRef.<field> as a string, false if missing or not a string.
-func roleRefString(bindingObj map[string]interface{}, field string) (string, bool) {
-	v, ok := workloadinterface.InspectMap(bindingObj, "roleRef", field)
+// objectString returns the string at path within obj, false if missing or not a string.
+// GetNamespace and GetApiVersion assert v.(string) without comma-ok, so they panic here.
+func objectString(obj map[string]interface{}, path ...string) (string, bool) {
+	v, ok := workloadinterface.InspectMap(obj, path...)
 	if !ok {
 		return "", false
 	}
@@ -39,44 +40,69 @@ func roleRefString(bindingObj map[string]interface{}, field string) (string, boo
 	return s, ok
 }
 
-// namespacesCompatible - an unset namespace means "whatever this is applied into",
-// which a file scan cannot know, so it matches anything. Cluster reads always set it.
+// namespacesCompatible - unset matches anything, on the binding side too: a namespace
+// less RoleBinding manifest still pairs with a Role anywhere, which beats losing every
+// finding written that way. Cluster reads, where the bug bites, always set it.
 func namespacesCompatible(roleNamespace, bindingNamespace string) bool {
 	return roleNamespace == "" || bindingNamespace == "" || roleNamespace == bindingNamespace
 }
 
-// bindingReferencesRole reports whether the roleRef of bindingWorkload resolves to
-// roleWorkload. Kind and name alone pair a binding with a same named Role from an
-// unrelated namespace, which the subject has no access to at all.
-func bindingReferencesRole(bindingWorkload, roleWorkload workloadinterface.IMetadata) bool {
-	bindingObj := bindingWorkload.GetObject()
+// roleIsNamespaced - by definition for Role and ClusterRole, by its namespace for a CRD.
+func roleIsNamespaced(roleKind, roleNamespace string) bool {
+	switch roleKind {
+	case "Role":
+		return true
+	case "ClusterRole":
+		return false
+	default:
+		return roleNamespace != ""
+	}
+}
 
-	name, ok := roleRefString(bindingObj, "name")
+// bindingResolvesNamespacedRole - a Role is bindable only by a RoleBinding, a CRD role by
+// any binding kind except a ClusterRoleBinding, which never reaches into a namespace.
+func bindingResolvesNamespacedRole(roleKind, bindingKind string) bool {
+	if roleKind == "Role" {
+		return bindingKind == "RoleBinding"
+	}
+	return bindingKind != "ClusterRoleBinding"
+}
+
+// bindingReferencesRole reports whether bindingWorkload's roleRef resolves to roleWorkload.
+// Kind and name alone pair it with a same named Role from an unrelated namespace.
+func bindingReferencesRole(bindingWorkload, roleWorkload workloadinterface.IMetadata) bool {
+	bindingObj, roleObj := bindingWorkload.GetObject(), roleWorkload.GetObject()
+
+	name, ok := objectString(bindingObj, "roleRef", "name")
 	if !ok || name != roleWorkload.GetName() {
 		return false
 	}
 
-	kind, ok := roleRefString(bindingObj, "kind")
-	if !ok || kind != roleWorkload.GetKind() {
+	kind, ok := objectString(bindingObj, "roleRef", "kind")
+	roleKind, roleKindOK := objectString(roleObj, "kind")
+	if !ok || !roleKindOK || kind != roleKind {
 		return false
 	}
 
-	// apiGroup is often omitted in hand written manifests
-	apiGroup, _ := roleRefString(bindingObj, "apiGroup")
-	roleGroup, _ := k8sinterface.SplitApiVersion(roleWorkload.GetApiVersion())
+	// apiGroup and the namespaces below are qualifiers: missing or corrupt reads as unset,
+	// so garbage in one cannot hide a subject from these rules
+	apiGroup, _ := objectString(bindingObj, "roleRef", "apiGroup")
+	apiVersion, _ := objectString(roleObj, "apiVersion")
+	roleGroup, _ := k8sinterface.SplitApiVersion(apiVersion)
 	if apiGroup != "" && roleGroup != "" && apiGroup != roleGroup {
 		return false
 	}
 
-	switch kind {
-	case "ClusterRole": // cluster scoped, either binding kind may reference it
-		return true
-	case "Role": // namespaced, only a RoleBinding alongside it resolves
-		return bindingWorkload.GetKind() == "RoleBinding" &&
-			namespacesCompatible(roleWorkload.GetNamespace(), bindingWorkload.GetNamespace())
-	default: // a CRD kind: keep pairing, but not across two namespaces that differ
-		return namespacesCompatible(roleWorkload.GetNamespace(), bindingWorkload.GetNamespace())
+	roleNamespace, _ := objectString(roleObj, "metadata", "namespace")
+	if !roleIsNamespaced(roleKind, roleNamespace) {
+		return true // cluster scoped, either binding kind may reference it
 	}
+
+	// namespaced, only a binding alongside it resolves
+	bindingKind, _ := objectString(bindingObj, "kind")
+	bindingNamespace, _ := objectString(bindingObj, "metadata", "namespace")
+	return bindingResolvesNamespacedRole(roleKind, bindingKind) &&
+		namespacesCompatible(roleNamespace, bindingNamespace)
 }
 
 func AggregateResourcesBySubjects(k8sObjects []workloadinterface.IMetadata) ([]workloadinterface.IMetadata, error) {

--- a/reporthandling/regoresourcesaggregator.go
+++ b/reporthandling/regoresourcesaggregator.go
@@ -29,35 +29,90 @@ func RegoResourcesAggregator(rule *PolicyRule, k8sObjects []workloadinterface.IM
 	return k8sObjects, nil
 }
 
+// roleRefString returns roleRef.<field> as a string, false if missing or not a string.
+func roleRefString(bindingObj map[string]interface{}, field string) (string, bool) {
+	v, ok := workloadinterface.InspectMap(bindingObj, "roleRef", field)
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// namespacesCompatible - an unset namespace means "whatever this is applied into",
+// which a file scan cannot know, so it matches anything. Cluster reads always set it.
+func namespacesCompatible(roleNamespace, bindingNamespace string) bool {
+	return roleNamespace == "" || bindingNamespace == "" || roleNamespace == bindingNamespace
+}
+
+// bindingReferencesRole reports whether the roleRef of bindingWorkload resolves to
+// roleWorkload. Kind and name alone pair a binding with a same named Role from an
+// unrelated namespace, which the subject has no access to at all.
+func bindingReferencesRole(bindingWorkload, roleWorkload workloadinterface.IMetadata) bool {
+	bindingObj := bindingWorkload.GetObject()
+
+	name, ok := roleRefString(bindingObj, "name")
+	if !ok || name != roleWorkload.GetName() {
+		return false
+	}
+
+	kind, ok := roleRefString(bindingObj, "kind")
+	if !ok || kind != roleWorkload.GetKind() {
+		return false
+	}
+
+	// apiGroup is often omitted in hand written manifests
+	apiGroup, _ := roleRefString(bindingObj, "apiGroup")
+	roleGroup, _ := k8sinterface.SplitApiVersion(roleWorkload.GetApiVersion())
+	if apiGroup != "" && roleGroup != "" && apiGroup != roleGroup {
+		return false
+	}
+
+	switch kind {
+	case "ClusterRole": // cluster scoped, either binding kind may reference it
+		return true
+	case "Role": // namespaced, only a RoleBinding alongside it resolves
+		return bindingWorkload.GetKind() == "RoleBinding" &&
+			namespacesCompatible(roleWorkload.GetNamespace(), bindingWorkload.GetNamespace())
+	default: // a CRD kind: keep pairing, but not across two namespaces that differ
+		return namespacesCompatible(roleWorkload.GetNamespace(), bindingWorkload.GetNamespace())
+	}
+}
+
 func AggregateResourcesBySubjects(k8sObjects []workloadinterface.IMetadata) ([]workloadinterface.IMetadata, error) {
 	aggregatedK8sObjects := []workloadinterface.IMetadata{}
 	for _, bindingWorkload := range k8sObjects {
-		if strings.HasSuffix(bindingWorkload.GetKind(), "Binding") { // types.Role
-			for _, roleWorkload := range k8sObjects {
-				if strings.HasSuffix(roleWorkload.GetKind(), "Role") {
-					bindingWorkloadObj := bindingWorkload.GetObject()
-					if kind, ok := workloadinterface.InspectMap(bindingWorkloadObj, "roleRef", "kind"); ok {
-						if name, ok := workloadinterface.InspectMap(bindingWorkloadObj, "roleRef", "name"); ok {
-							if kind.(string) == roleWorkload.GetKind() && name.(string) == roleWorkload.GetName() {
-								if subjects, ok := workloadinterface.InspectMap(bindingWorkloadObj, "subjects"); ok {
-									if data, ok := subjects.([]interface{}); ok {
-										for _, subject := range data {
-											// deep copy subject - don't change original subject in rolebinding
-											subjectCopy, err := DeepCopyMap(subject.(map[string]interface{}))
-											if err != nil {
-												return aggregatedK8sObjects, err
-											}
-											// subjectCopy["apiVersion"] = fmt.Sprintf("%s/%s", objectsenvelopes.RegoAttackVectorGroup, objectsenvelopes.RegoAttackVectorVersion)
-											subjectCopy[objectsenvelopes.RelatedObjectsKey] = []map[string]interface{}{bindingWorkload.GetObject(), roleWorkload.GetObject()}
-											newObj := objectsenvelopes.NewRegoResponseVectorObject(subjectCopy)
-											aggregatedK8sObjects = append(aggregatedK8sObjects, newObj)
-										}
-									}
-								}
-							}
-						}
-					}
+		if !strings.HasSuffix(bindingWorkload.GetKind(), "Binding") {
+			continue
+		}
+		subjects, ok := workloadinterface.InspectMap(bindingWorkload.GetObject(), "subjects")
+		if !ok {
+			continue
+		}
+		data, ok := subjects.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, roleWorkload := range k8sObjects {
+			if !strings.HasSuffix(roleWorkload.GetKind(), "Role") {
+				continue
+			}
+			if !bindingReferencesRole(bindingWorkload, roleWorkload) {
+				continue
+			}
+			for _, subject := range data {
+				subjectMap, ok := subject.(map[string]interface{})
+				if !ok {
+					continue
 				}
+				// deep copy subject - don't change original subject in rolebinding
+				subjectCopy, err := DeepCopyMap(subjectMap)
+				if err != nil {
+					return aggregatedK8sObjects, err
+				}
+				subjectCopy[objectsenvelopes.RelatedObjectsKey] = []map[string]interface{}{bindingWorkload.GetObject(), roleWorkload.GetObject()}
+				newObj := objectsenvelopes.NewRegoResponseVectorObject(subjectCopy)
+				aggregatedK8sObjects = append(aggregatedK8sObjects, newObj)
 			}
 		}
 	}

--- a/reporthandling/regoresourcesaggregator_test.go
+++ b/reporthandling/regoresourcesaggregator_test.go
@@ -2,11 +2,13 @@ package reporthandling
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/opa-utils/objectsenvelopes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -57,6 +59,170 @@ func TestAggregateResourcesBySubjects2(t *testing.T) {
 
 	assert.Equal(t, 1, len(outputList))
 	assert.True(t, isObjectFields(outputList))
+}
+
+func rbacRoleRef(kind, name string) string {
+	return fmt.Sprintf(`{"apiGroup": "rbac.authorization.k8s.io", "kind": %q, "name": %q}`, kind, name)
+}
+
+// an empty namespace yields a cluster scoped object
+func rbacMetadata(name, namespace string) string {
+	if namespace == "" {
+		return fmt.Sprintf(`{"name": %q}`, name)
+	}
+	return fmt.Sprintf(`{"name": %q, "namespace": %q}`, name, namespace)
+}
+
+func rbacRole(kind, name, namespace string) string {
+	return fmt.Sprintf(`{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": %q, "metadata": %s, "rules": [{"apiGroups": [""], "resources": ["pods"], "verbs": ["create"]}]}`,
+		kind, rbacMetadata(name, namespace))
+}
+
+// roleRef is spliced in verbatim so a case can omit or corrupt individual fields
+func rbacBinding(kind, name, namespace, roleRef string) string {
+	return fmt.Sprintf(`{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": %q, "metadata": %s, "roleRef": %s, "subjects": [{"kind": "ServiceAccount", "name": "sa-a", "namespace": "ns-a"}]}`,
+		kind, rbacMetadata(name, namespace), roleRef)
+}
+
+func newRBACObject(t *testing.T, manifest string) workloadinterface.IMetadata {
+	t.Helper()
+	obj := make(map[string]interface{})
+	require.NoError(t, json.Unmarshal([]byte(manifest), &obj))
+	o := objectsenvelopes.NewObject(obj)
+	require.NotNil(t, o, "manifest did not map to a known object type: %s", manifest)
+	return o
+}
+
+// pins the RBAC resolution rules the aggregator must honour: matching roleRef on
+// kind and name alone paired a binding with a same named Role from an unrelated
+// namespace, and every rule using this aggregator reported that pair as a finding.
+func TestAggregateResourcesBySubjectsRoleRefResolution(t *testing.T) {
+	testCases := []struct {
+		objects []string
+		desc    string
+		// when set, the namespace of the Role expected in relatedObjects
+		expectedRoleNamespace string
+		expectedCount         int
+	}{
+		{
+			desc: "RoleBinding resolves a Role in its own namespace",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				rbacBinding("RoleBinding", "rb", "ns-a", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-a",
+		},
+		{
+			desc: "RoleBinding does not resolve a same named Role from another namespace",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-b"),
+				rbacBinding("RoleBinding", "rb", "ns-a", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount: 0,
+		},
+		{
+			desc: "with the name reused across namespaces only the local Role is aggregated",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				rbacRole("Role", "shared-name", "ns-b"),
+				rbacBinding("RoleBinding", "rb", "ns-a", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-a",
+		},
+		{
+			// a file scan cannot know the namespace, so resolving beats losing the finding
+			desc: "a Role with no namespace set still resolves",
+			objects: []string{
+				rbacRole("Role", "shared-name", ""),
+				rbacBinding("RoleBinding", "rb", "ns-a", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount: 1,
+		},
+		{
+			desc: "RoleBinding resolves a ClusterRole, which is not namespaced",
+			objects: []string{
+				rbacRole("ClusterRole", "shared-name", ""),
+				rbacBinding("RoleBinding", "rb", "ns-a", rbacRoleRef("ClusterRole", "shared-name")),
+			},
+			expectedCount: 1,
+		},
+		{
+			desc: "ClusterRoleBinding resolves a ClusterRole",
+			objects: []string{
+				rbacRole("ClusterRole", "shared-name", ""),
+				rbacBinding("ClusterRoleBinding", "crb", "", rbacRoleRef("ClusterRole", "shared-name")),
+			},
+			expectedCount: 1,
+		},
+		{
+			desc: "ClusterRoleBinding does not resolve a namespaced Role",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				rbacBinding("ClusterRoleBinding", "crb", "", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount: 0,
+		},
+		{
+			desc: "roleRef pointing at another apiGroup does not resolve",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				rbacBinding("RoleBinding", "rb", "ns-a", `{"apiGroup": "example.com", "kind": "Role", "name": "shared-name"}`),
+			},
+			expectedCount: 0,
+		},
+		{
+			desc: "roleRef without an apiGroup still resolves",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				rbacBinding("RoleBinding", "rb", "ns-a", `{"kind": "Role", "name": "shared-name"}`),
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-a",
+		},
+		{
+			desc: "a roleRef kind that is not a string is skipped, not fatal",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				rbacBinding("RoleBinding", "rb", "ns-a", `{"apiGroup": "rbac.authorization.k8s.io", "kind": 1, "name": "shared-name"}`),
+			},
+			expectedCount: 0,
+		},
+		{
+			desc: "a subject that is not an object is skipped, not fatal",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				`{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "RoleBinding", "metadata": {"name": "rb", "namespace": "ns-a"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": "shared-name"}, "subjects": ["not-an-object"]}`,
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			inputList := make([]workloadinterface.IMetadata, 0, len(tt.objects))
+			for _, manifest := range tt.objects {
+				inputList = append(inputList, newRBACObject(t, manifest))
+			}
+
+			outputList, err := AggregateResourcesBySubjects(inputList)
+			assert.NoError(t, err)
+			assert.Len(t, outputList, tt.expectedCount)
+
+			if tt.expectedRoleNamespace == "" || len(outputList) == 0 {
+				return
+			}
+
+			// relatedObjects is ordered [binding, role]
+			related, ok := outputList[0].GetObject()[objectsenvelopes.RelatedObjectsKey].([]map[string]interface{})
+			require.True(t, ok, "relatedObjects should be a list of objects")
+			require.Len(t, related, 2)
+			metadata, ok := related[1]["metadata"].(map[string]interface{})
+			require.True(t, ok, "the related role should carry metadata")
+			assert.Equal(t, tt.expectedRoleNamespace, metadata["namespace"], "the Role from the binding's own namespace should be aggregated")
+		})
+	}
 }
 
 func isObjectFields(objs []workloadinterface.IMetadata) bool {

--- a/reporthandling/regoresourcesaggregator_test.go
+++ b/reporthandling/regoresourcesaggregator_test.go
@@ -78,6 +78,21 @@ func rbacRole(kind, name, namespace string) string {
 		kind, rbacMetadata(name, namespace))
 }
 
+// a role like CRD kind, outside rbac.authorization.k8s.io
+func crdRole(kind, name, namespace string) string {
+	return fmt.Sprintf(`{"apiVersion": "example.com/v1", "kind": %q, "metadata": %s, "rules": []}`,
+		kind, rbacMetadata(name, namespace))
+}
+
+func crdRoleRef(kind, name string) string {
+	return fmt.Sprintf(`{"apiGroup": "example.com", "kind": %q, "name": %q}`, kind, name)
+}
+
+func crdBinding(kind, name, namespace, roleRef string) string {
+	return fmt.Sprintf(`{"apiVersion": "example.com/v1", "kind": %q, "metadata": %s, "roleRef": %s, "subjects": [{"kind": "ServiceAccount", "name": "sa-a", "namespace": "ns-a"}]}`,
+		kind, rbacMetadata(name, namespace), roleRef)
+}
+
 // roleRef is spliced in verbatim so a case can omit or corrupt individual fields
 func rbacBinding(kind, name, namespace, roleRef string) string {
 	return fmt.Sprintf(`{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": %q, "metadata": %s, "roleRef": %s, "subjects": [{"kind": "ServiceAccount", "name": "sa-a", "namespace": "ns-a"}]}`,
@@ -93,9 +108,8 @@ func newRBACObject(t *testing.T, manifest string) workloadinterface.IMetadata {
 	return o
 }
 
-// pins the RBAC resolution rules the aggregator must honour: matching roleRef on
-// kind and name alone paired a binding with a same named Role from an unrelated
-// namespace, and every rule using this aggregator reported that pair as a finding.
+// pins the RBAC resolution rules: kind and name alone paired a binding with a same
+// named Role from an unrelated namespace, and every rule using it reported that pair.
 func TestAggregateResourcesBySubjectsRoleRefResolution(t *testing.T) {
 	testCases := []struct {
 		objects []string
@@ -157,10 +171,65 @@ func TestAggregateResourcesBySubjectsRoleRefResolution(t *testing.T) {
 			expectedCount: 1,
 		},
 		{
+			// a binding leaves its namespace to the apply context as often as a role does
+			desc: "a binding with no namespace set still resolves a Role in any namespace",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-b"),
+				rbacBinding("RoleBinding", "rb", "", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-b",
+		},
+		{
 			desc: "ClusterRoleBinding does not resolve a namespaced Role",
 			objects: []string{
 				rbacRole("Role", "shared-name", "ns-a"),
 				rbacBinding("ClusterRoleBinding", "crb", "", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount: 0,
+		},
+		{
+			desc: "RoleBinding resolves a CRD role in its own namespace",
+			objects: []string{
+				crdRole("ProjectRole", "shared-name", "ns-a"),
+				rbacBinding("RoleBinding", "rb", "ns-a", crdRoleRef("ProjectRole", "shared-name")),
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-a",
+		},
+		{
+			// the kind does not say whether a CRD is namespaced, so its namespace decides
+			desc: "ClusterRoleBinding does not resolve a namespaced CRD role",
+			objects: []string{
+				crdRole("ProjectRole", "shared-name", "ns-a"),
+				rbacBinding("ClusterRoleBinding", "crb", "", crdRoleRef("ProjectRole", "shared-name")),
+			},
+			expectedCount: 0,
+		},
+		{
+			desc: "ClusterRoleBinding resolves a CRD role with no namespace",
+			objects: []string{
+				crdRole("ProjectRole", "shared-name", ""),
+				rbacBinding("ClusterRoleBinding", "crb", "", crdRoleRef("ProjectRole", "shared-name")),
+			},
+			expectedCount: 1,
+		},
+		{
+			// only a ClusterRoleBinding is known not to reach into a namespace, so a CRD
+			// binding kind keeps resolving its own CRD role
+			desc: "a CRD binding resolves a CRD role in its own namespace",
+			objects: []string{
+				crdRole("ProjectRole", "shared-name", "ns-a"),
+				crdBinding("ProjectRoleBinding", "prb", "ns-a", crdRoleRef("ProjectRole", "shared-name")),
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-a",
+		},
+		{
+			desc: "a CRD binding does not resolve a CRD role in another namespace",
+			objects: []string{
+				crdRole("ProjectRole", "shared-name", "ns-b"),
+				crdBinding("ProjectRoleBinding", "prb", "ns-a", crdRoleRef("ProjectRole", "shared-name")),
 			},
 			expectedCount: 0,
 		},
@@ -188,6 +257,42 @@ func TestAggregateResourcesBySubjectsRoleRefResolution(t *testing.T) {
 				rbacBinding("RoleBinding", "rb", "ns-a", `{"apiGroup": "rbac.authorization.k8s.io", "kind": 1, "name": "shared-name"}`),
 			},
 			expectedCount: 0,
+		},
+		{
+			// a corrupt qualifier reads as unset, never as a way to hide a subject
+			desc: "a roleRef apiGroup that is not a string is read as unset, not fatal",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				rbacBinding("RoleBinding", "rb", "ns-a", `{"apiGroup": 5, "kind": "Role", "name": "shared-name"}`),
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-a",
+		},
+		{
+			desc: "a role apiVersion that is not a string is read as unset, not fatal",
+			objects: []string{
+				`{"apiVersion": 1, "kind": "Role", "metadata": {"name": "shared-name", "namespace": "ns-a"}, "rules": []}`,
+				rbacBinding("RoleBinding", "rb", "ns-a", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-a",
+		},
+		{
+			desc: "a role namespace that is not a string is read as unset, not fatal",
+			objects: []string{
+				`{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role", "metadata": {"name": "shared-name", "namespace": 7}, "rules": []}`,
+				rbacBinding("RoleBinding", "rb", "ns-a", rbacRoleRef("Role", "shared-name")),
+			},
+			expectedCount: 1,
+		},
+		{
+			desc: "a binding namespace that is not a string is read as unset, not fatal",
+			objects: []string{
+				rbacRole("Role", "shared-name", "ns-a"),
+				`{"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "RoleBinding", "metadata": {"name": "rb", "namespace": 7}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": "shared-name"}, "subjects": [{"kind": "ServiceAccount", "name": "sa-a", "namespace": "ns-a"}]}`,
+			},
+			expectedCount:         1,
+			expectedRoleNamespace: "ns-a",
 		},
 		{
 			desc: "a subject that is not an object is skipped, not fatal",


### PR DESCRIPTION
## Description

`AggregateResourcesBySubjects` pairs a `*Binding` with a `*Role` on `roleRef.kind` + `roleRef.name` only. It never compares namespaces, and never checks that the binding kind is compatible with the referenced role kind.

Kubernetes resolves a RoleBinding's `roleRef` to a Role **strictly within the binding's own namespace**, so a same-named Role in a different namespace is something the subject has no access to at all. Reusing role names across namespaces is routine (`edit`, `admin`, `developer`, Helm charts installed into several namespaces), so this is not a corner case - the noise grows with the number of namespaces sharing a name.

Every RBAC attack-vector rule delegates roleRef resolution entirely to this aggregator - the Rego only re-checks `endswith(role.kind, "Role")` and `endswith(rolebinding.kind, "Binding")` - so a bogus pairing becomes a reported finding with no downstream filter to catch it. 17 of the 19 rules carrying `resourcesAggregator: subject-role-rolebinding` are affected; `cluster-admin-role` and `system-authenticated-allowed-to-take-over-cluster` are immune only because they assert `rolebinding.kind == "ClusterRoleBinding"` themselves.

### How to reproduce

Given `Role/shared-name` in `ns-a` (`rules: []`), `Role/shared-name` in `ns-b` (grants `create` on pods), and `RoleBinding/rb` in `ns-a` bound to `ServiceAccount/sa-a`, `sa-a` can create nothing. Running the verbatim `rule-can-create-pod` Rego through the testrunner reports:

```
alertMessage: "Subject: ServiceAccount-sa-a can create pods"
relatedObjects[0]: RoleBinding rb      (namespace: ns-a)
relatedObjects[1]: Role shared-name    (namespace: ns-b)   <- unreachable from ns-a
```

## The fix

Resolution now follows the RBAC rules, in a new `bindingReferencesRole` helper:

| `roleRef.kind` | Requirement |
|---|---|
| `Role` | binding must be a `RoleBinding` **and** share the role's namespace |
| `ClusterRole` | role must be a `ClusterRole`; namespace irrelevant, either binding kind may reference it |
| any | `roleRef.apiGroup`, when set, must match the role's own API group |

An **unset** namespace is treated as unspecified rather than as a mismatch. Plain manifests leave the namespace to the apply context and a file scan cannot know it, so resolving beats losing the finding. Objects read from a cluster always carry their namespace, so this does not weaken a cluster scan - which is where the bug bites.

Also in this change:

- Unchecked type assertions (`kind.(string)`, `name.(string)`, `subject.(map[string]interface{})`) replaced with comma-ok. A `roleRef.kind` that is not a string previously **panicked** mid-scan on user-supplied YAML.
- The five-deep `if` nest flattened into guard clauses, and the `subjects` lookup hoisted out of the inner loop since it depends only on the binding.

Preserved exactly: the `[binding, role]` ordering of `relatedObjects` (the Rego indexes it positionally), deep-copy-subject-only, and the partial-slice-plus-error return path the caller relies on.

## Testing

- New table-driven suite, 11 cases, covering the cross-namespace reproduction, both `ClusterRole` paths, the `ClusterRoleBinding` → namespaced `Role` variant, apiGroup mismatch, and the malformed-input cases. Verified non-vacuous: 5 of them fail against the previous code, one with a panic.
- Both pre-existing aggregator tests untouched and passing.
- `go build ./...`, `go vet`, `gofmt`, and `go test -race ./...` green across all packages.
- **regolibrary `TestAllRules`** run against this branch via a temporary `replace`: 0 failures, matching the pre-change baseline. The reproduction above was added as a temporary fixture and confirmed to fail before / pass after; the legitimate `RoleBinding` → `ClusterRole` fixture (`rule-can-create-pod/test/clusterrole-rolebinding`) keeps working.

## Notes

There is a related, independent issue in how resources are bucketed per namespace before reaching the aggregator. The two interact - per-namespace bucketing incidentally suppresses these false positives, which is part of why the two modes there disagree - but this one is a plain false positive present on whole-cluster scans on its own.

This reaches scans once `opa-utils` is tagged and `kubescape` bumps the dependency.


Fixes: https://github.com/kubescape/kubescape/issues/2579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RBAC resource association for RoleBindings/ClusterRoleBindings with namespaces, missing fields, and API-group variations.
  * Added compatibility for empty namespaces (treated as a wildcard) and more reliable Role/ClusterRole matching rules.
  * Safely skip malformed subject entries to prevent aggregation failures.
  * Preserve related-object metadata, including correct namespace details, during aggregation.
* **Tests**
  * Added comprehensive, table-driven coverage for roleRef resolution across standard RBAC and CRD-like RBAC scenarios, including invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->