### PR TITLE
fix(resources): migrate embedded Rego dependencies to Rego v1 syntax

### DIFF
--- a/resources/dependencies.go
+++ b/resources/dependencies.go
@@ -2,8 +2,9 @@ package resources
 
 var RegoCAUtils = `
 package cautils
+import rego.v1
 
-list_contains(lista,element) {
+list_contains(lista,element) if {
   some i
   lista[i] == element
 }
@@ -11,13 +12,13 @@ list_contains(lista,element) {
 # getPodName(metadata) = name {
 # 	name := metadata.generateName
 #}
-getPodName(metadata) = name {
+getPodName(metadata) = name if {
     name := metadata.name
 }
 
 #returns subobject ,sub1 is partial to parent,  e.g parent = {a:a,b:b,c:c,d:d}
 # sub1 = {b:b,c:c} - result is {b:b,c:c}, if sub1={b:b,e:f} returns {b:b}
-object_intersection(parent,sub1) = r{
+object_intersection(parent,sub1) = r if {
 
   r := {k:p  | p := sub1[k]
               parent[k]== p
@@ -25,12 +26,12 @@ object_intersection(parent,sub1) = r{
 }
 
 #returns if parent contains sub(both are objects not sets!!)
-is_subobject(sub,parent) {
+is_subobject(sub,parent) if {
 object_intersection(sub,parent)  == sub
 }
 
 # parse unix permissions
-unix_permission(perm) = ret {
+unix_permission(perm) = ret if {
     ret := {
         "user": unix_permission_from_octal(bits.rsh(perm, 6)), 
         "group": unix_permission_from_octal(bits.rsh(perm, 3)),
@@ -42,7 +43,7 @@ unix_permission(perm) = ret {
 }
 
 # parse single unix permission (one octal digit)
-unix_permission_from_octal(perm) = ret {
+unix_permission_from_octal(perm) = ret if {
     ret := {
         "exec": bits.and(perm, 1) != 0,
         "write": bits.and(perm, 2) != 0,
@@ -51,13 +52,13 @@ unix_permission_from_octal(perm) = ret {
 }
 
 # check that the given permissions are more permissive than 644
-is_not_strict_conf_permission(p){
+is_not_strict_conf_permission(p) if {
     not is_strict_conf_permission(p)
 }
 
 # check that the given permissions are 644 or above
 # deprecated. use 'unix_permissions_allow' instead
-is_strict_conf_permission(p){
+is_strict_conf_permission(p) if {
     perm := unix_permission(p)
     not perm.user.exec
     not perm.group.write
@@ -70,7 +71,7 @@ is_strict_conf_permission(p){
 }
 
 # check if (unix permission integers) 'actual' permissions allowed by 'allow'
-unix_permissions_allow(allow, actual) {
+unix_permissions_allow(allow, actual) if {
     allow_parsed := unix_permission(allow)
     actual_parsed := unix_permission(actual)
     
@@ -91,25 +92,25 @@ unix_permissions_allow(allow, actual) {
 # true, false => true
 # false, false => ture
 # false, true => false
-_unix_perm_allow(allow, actual) {
+_unix_perm_allow(allow, actual) if {
     allow == true
 }
-_unix_perm_allow(allow, actual) {
+_unix_perm_allow(allow, actual) if {
     allow == actual
 }
 
 # Check if file ownership is different than root:root
-is_not_strict_conf_ownership(ownership){
+is_not_strict_conf_ownership(ownership) if {
     not is_strict_conf_ownership(ownership)
 }
 
 # File ownership check only if there is no error
-is_strict_conf_ownership(ownership){
+is_strict_conf_ownership(ownership) if {
     ownership.err
 }
 
 # Ensure file ownership are root:root
-is_strict_conf_ownership(ownership){
+is_strict_conf_ownership(ownership) if {
     ownership.uid == 0
     ownership.gid == 0
 }
@@ -117,6 +118,7 @@ is_strict_conf_ownership(ownership){
 
 var RegoDesignators = `
 package designators
+import rego.v1
 
 import data.cautils
 #functions that related to designators
@@ -125,7 +127,7 @@ import data.cautils
 #@input@: receive as part of the input object "included_namespaces" list
 #@input@: item's namespace as "namespace"
 #returns true if namespace exists in that list
-included_namespaces(namespace){
+included_namespaces(namespace) if {
     cautils.list_contains(["default"],namespace)
 }
 
@@ -133,15 +135,15 @@ included_namespaces(namespace){
 #@input@: receive as part of the input object "forbidden_namespaces" list
 #@input@: item's namespace as "namespace"
 #returns true if namespace exists in that list
-excluded_namespaces(namespace){
+excluded_namespaces(namespace) if {
     not cautils.list_contains(["excluded"],namespace)
 }
 
-forbidden_wlids(wlid){
+forbidden_wlids(wlid) if {
     input.forbidden_wlids[_] == wlid
 }
 
-filter_k8s_object(obj) = filtered {
+filter_k8s_object(obj) = filtered if {
     #put 
     filtered := obj
     	#filtered := [ x | cautils.list_contains(["default"],obj[i].metadata.namespace) ; x := obj[i] ]
@@ -151,6 +153,7 @@ filter_k8s_object(obj) = filtered {
 `
 var RegoKubernetesApiClient = `
 package kubernetes.api.client
+import rego.v1
 
 # service account token
 token :=  data.k8sconfig.token
@@ -293,7 +296,7 @@ query_all_no_auth(resource) = http.send({
 }) 
 
 
-field_transform_to_qry_param(field,map) = finala {
+field_transform_to_qry_param(field,map) = finala if {
 	mid := {concat(".",[field,key]): val | val := map[key]}
     finala := label_map_to_query_string(mid)
 }

--- a/resources/dependencies_test.go
+++ b/resources/dependencies_test.go
@@ -1,0 +1,119 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
+)
+
+func TestRegoModulesCompile(t *testing.T) {
+	modules := map[string]string{
+		"cautils.rego":               RegoCAUtils,
+		"designators.rego":           RegoDesignators,
+		"kubernetes_api_client.rego": RegoKubernetesApiClient,
+	}
+
+	for _, regoVersion := range []ast.RegoVersion{ast.RegoV1, ast.RegoV0} {
+		t.Run(regoVersion.String(), func(t *testing.T) {
+			compiler := ast.NewCompiler().WithDefaultRegoVersion(regoVersion)
+
+			parsed := make(map[string]*ast.Module, len(modules))
+			for filename, src := range modules {
+				module, err := ast.ParseModuleWithOpts(filename, src, ast.ParserOptions{RegoVersion: regoVersion})
+				if err != nil {
+					t.Fatalf("failed to parse %s under %s: %v", filename, regoVersion, err)
+				}
+				parsed[filename] = module
+			}
+
+			compiler.Compile(parsed)
+			if compiler.Failed() {
+				t.Fatalf("compilation failed under %s: %v", regoVersion, compiler.Errors)
+			}
+		})
+	}
+}
+
+func evalSingleResult(t *testing.T, ctx context.Context, query string) interface{} {
+	t.Helper()
+
+	r := rego.New(
+		rego.Query(query),
+		rego.Module("cautils.rego", RegoCAUtils),
+		rego.Module("designators.rego", RegoDesignators),
+	)
+
+	rs, err := r.Eval(ctx)
+	if err != nil {
+		t.Fatalf("eval error for query %q: %v", query, err)
+	}
+	if len(rs) != 1 || len(rs[0].Expressions) != 1 {
+		t.Fatalf("unexpected result set for query %q: %#v", query, rs)
+	}
+	return rs[0].Expressions[0].Value
+}
+
+func TestRegoCAUtilsEval(t *testing.T) {
+	ctx := context.Background()
+
+	if v := evalSingleResult(t, ctx, `data.cautils.list_contains(["a","b"], "b")`); v != true {
+		t.Errorf("list_contains: expected true, got %v", v)
+	}
+
+	if v := evalSingleResult(t, ctx, `data.cautils.getPodName({"name": "foo"})`); v != "foo" {
+		t.Errorf("getPodName: expected \"foo\", got %v", v)
+	}
+
+	permResult := evalSingleResult(t, ctx, `data.cautils.unix_permission(420)`)
+	perm, ok := permResult.(map[string]interface{})
+	if !ok {
+		t.Fatalf("unix_permission: expected map result, got %#v", permResult)
+	}
+	expectBits := map[string]map[string]bool{
+		"user":     {"read": true, "write": true, "exec": false},
+		"group":    {"read": true, "write": false, "exec": false},
+		"everyone": {"read": true, "write": false, "exec": false},
+	}
+	for section, bits := range expectBits {
+		got, ok := perm[section].(map[string]interface{})
+		if !ok {
+			t.Fatalf("unix_permission: missing section %q in %#v", section, perm)
+		}
+		for bit, want := range bits {
+			if got[bit] != want {
+				t.Errorf("unix_permission.%s.%s: expected %v, got %v", section, bit, want, got[bit])
+			}
+		}
+	}
+
+	if v := evalSingleResult(t, ctx, `data.cautils.unix_permissions_allow(420, 384)`); v != true {
+		t.Errorf("unix_permissions_allow(0644, 0600): expected true, got %v", v)
+	}
+}
+
+func TestRegoDesignatorsEval(t *testing.T) {
+	ctx := context.Background()
+
+	if v := evalSingleResult(t, ctx, `data.designators.included_namespaces("default")`); v != true {
+		t.Errorf("included_namespaces: expected true, got %v", v)
+	}
+
+	// excluded_namespaces("excluded") is undefined (not false): the rule body
+	// `not cautils.list_contains(["excluded"], "excluded")` fails since "excluded"
+	// is in the list, so the partial-function rule has no matching definition
+	// and Rego yields an empty result set rather than a false value.
+	r := rego.New(
+		rego.Query(`data.designators.excluded_namespaces("excluded")`),
+		rego.Module("cautils.rego", RegoCAUtils),
+		rego.Module("designators.rego", RegoDesignators),
+	)
+	rs, err := r.Eval(ctx)
+	if err != nil {
+		t.Fatalf("eval error for excluded_namespaces: %v", err)
+	}
+	if len(rs) != 0 {
+		t.Errorf("excluded_namespaces: expected undefined (empty result set), got %#v", rs)
+	}
+}


### PR DESCRIPTION
## Summary
- Migrate `RegoCAUtils`, `RegoDesignators`, and `RegoKubernetesApiClient` in `resources/dependencies.go` from pre-OPA-1.0 (Rego v0) syntax to Rego v1 (`import rego.v1` + `if` keyword before rule bodies), matching the migration already done for the regolibrary rule set.
- The migrated syntax also compiles cleanly under the legacy `RegoV0` parser, so this is backward compatible — no coordination needed with downstream consumers' own migration timing (e.g. kubescape/kubescape#2359).
- Adds `resources/dependencies_test.go`: a compile test asserting all three modules compile together (exercising `designators`' cross-module `import data.cautils`) under both `RegoV1` and `RegoV0`, plus eval smoke tests locking in unchanged behavior for the core helper functions (`list_contains`, `unix_permission`, `unix_permissions_allow`, `getPodName`, `included_namespaces`/`excluded_namespaces`).
- Out of scope: `reporthandling/datastructures_mock.go` also embeds v0-syntax Rego (with partial-set rules needing `contains`, a different conversion shape), but it's dead/unused-in-production mock/test-fixture code — filing as a follow-up rather than bundling here.

Fixes #178

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes across all packages
- [x] New compile test verified to fail against the pre-migration source with the exact issue error (`rego_parse_error: 'if' keyword is required before function body`), and pass post-migration under both `RegoV1` and `RegoV0`
- [x] `git diff` limited to the itemized syntax additions only — no incidental logic/formatting changes
- [x] Independent verification pass re-derived all checks (diff scope, compile correctness, eval semantics, build/test) rather than trusting self-report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: oh-my-claudecode:team | cmds: /oh-my-claudecode:ralplan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated embedded policy definitions to support Rego v1 syntax while maintaining compatibility with Rego v0.
  * Preserved existing permission, ownership, designator, and Kubernetes request behavior.

* **Quality Improvements**
  * Added automated validation to confirm policy compilation and expected evaluation results across supported scenarios.
  * Added coverage for Unix permission checks and cases involving undefined excluded namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->